### PR TITLE
Change many if not all copies of Result to references to reduce memory load

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ result.Time() time.Time
 result.Array() []gjson.Result
 result.Map() map[string]gjson.Result
 result.Get(path string) Result
-result.ForEach(iterator func(key, value Result) bool)
+result.ForEach(iterator func(key, value *Result) bool)
 result.Less(token Result, caseSensitive bool) bool
 ```
 

--- a/gjson.go
+++ b/gjson.go
@@ -1254,6 +1254,12 @@ func parseSquash(json string, i int) (int, string) {
 	return i, json[s:]
 }
 
+func (c *parseContext) resultify() {
+	if c.value == nil {
+		c.value = &Result{}
+	}
+}
+
 func parseObject(c *parseContext, i int, path string) (int, bool) {
 	var pmatch, kesc, vesc, ok, hit bool
 	var key, val string
@@ -1342,9 +1348,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 					return i, false
 				}
 				if hit {
-					if c.value == nil {
-						c.value = &Result{}
-					}
+					c.resultify()
 					if vesc {
 						c.value.Str = unescape(val[1 : len(val)-1])
 					} else {
@@ -1363,9 +1367,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				} else {
 					i, val = parseSquash(c.json, i)
 					if hit {
-						if c.value == nil {
-							c.value = &Result{}
-						}
+						c.resultify()
 						c.value.Raw = val
 						c.value.Type = JSON
 						return i, true
@@ -1380,9 +1382,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				} else {
 					i, val = parseSquash(c.json, i)
 					if hit {
-						if c.value == nil {
-							c.value = &Result{}
-						}
+						c.resultify()
 						c.value.Raw = val
 						c.value.Type = JSON
 						return i, true
@@ -1398,9 +1398,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				vc := c.json[i]
 				i, val = parseLiteral(c.json, i)
 				if hit {
-					if c.value == nil {
-						c.value = &Result{}
-					}
+					c.resultify()
 					c.value.Raw = val
 					switch vc {
 					case 't':
@@ -1417,9 +1415,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 			if num {
 				i, val = parseNumber(c.json, i)
 				if hit {
-					if c.value == nil {
-						c.value = &Result{}
-					}
+					c.resultify()
 					c.value.Raw = val
 					c.value.Type = Number
 					c.value.Num, _ = strconv.ParseFloat(val, 64)
@@ -1698,9 +1694,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					if rp.alogok {
 						break
 					}
-					if c.value == nil {
-						c.value = &Result{}
-					}
+					c.resultify()
 					if vesc {
 						c.value.Str = unescape(val[1 : len(val)-1])
 					} else {
@@ -1729,9 +1723,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 						if rp.alogok {
 							break
 						}
-						if c.value == nil {
-							c.value = &Result{}
-						}
+						c.resultify()
 						c.value.Raw = val
 						c.value.Type = JSON
 						return i, true
@@ -1756,9 +1748,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 						if rp.alogok {
 							break
 						}
-						if c.value == nil {
-							c.value = &Result{}
-						}
+						c.resultify()
 						c.value.Raw = val
 						c.value.Type = JSON
 						return i, true
@@ -1789,9 +1779,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					if rp.alogok {
 						break
 					}
-					if c.value == nil {
-						c.value = &Result{}
-					}
+					c.resultify()
 					c.value.Raw = val
 					switch vc {
 					case 't':
@@ -1846,9 +1834,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 							}
 						}
 						jsons = append(jsons, ']')
-						if c.value == nil {
-							c.value = &Result{}
-						}
+						c.resultify()
 						c.value.Type = JSON
 						c.value.Raw = string(jsons)
 						c.value.Indexes = indexes
@@ -1857,9 +1843,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					if rp.alogok {
 						break
 					}
-					if c.value == nil {
-						c.value = &Result{}
-					}
+					c.resultify()
 					c.value.Type = Number
 					c.value.Num = float64(h - 1)
 					c.value.Raw = strconv.Itoa(h - 1)
@@ -1868,20 +1852,12 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				}
 				if c.value == nil || !c.value.Exists() {
 					if len(multires) > 0 {
-						if c.value == nil {
-							c.value = &Result{}
-						} else {
-							c.value.Clear()
-						}
+						c.resultify()
 						c.value.Raw = string(append(multires, ']'))
 						c.value.Type = JSON
 						c.value.Indexes = queryIndexes
 					} else if rp.query.all {
-						if c.value == nil {
-							c.value = &Result{}
-						} else {
-							c.value.Clear()
-						}
+						c.resultify()
 						c.value.Raw="[]"
 						c.value.Type=JSON
 					}
@@ -1902,9 +1878,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					if rp.alogok {
 						break
 					}
-					if c.value == nil {
-						c.value = &Result{}
-					}
+					c.resultify()
 					c.value.Raw = val
 					c.value.Type = Number
 					c.value.Num, _ = strconv.ParseFloat(val, 64)
@@ -3492,9 +3466,7 @@ func getBytes(json []byte, path string) *Result {
 // of the resulting value. If the position cannot be found then Index zero is
 // used instead.
 func fillIndex(json string, c *parseContext) {
-	if c.value == nil {
-		c.value = &Result{}
-	}
+	c.resultify()
 	if len(c.value.Raw) > 0 && !c.calcd {
 		jhdr := *(*stringHeader)(unsafe.Pointer(&json))
 		rhdr := *(*stringHeader)(unsafe.Pointer(&(c.value.Raw)))

--- a/gjson.go
+++ b/gjson.go
@@ -2167,7 +2167,7 @@ func (t *Result) getDeepPathModifiers(path string) (*Result, bool) {
 	if ok {
 		path = npath
 		if len(path) > 0 && (path[0] == '|' || path[0] == '.') {
-			res := Get(rjson, path[1:])
+			res := (&Result{Raw: rjson}).Get(path[1:])
 			res.Index = 0
 			res.Indexes = nil
 			return res, true

--- a/gjson.go
+++ b/gjson.go
@@ -1802,17 +1802,17 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 							if idx < len(c.json) && c.json[idx] != ']' {
 								_, res, ok := parseAny(c.json, idx, true)
 								if ok {
-									res := res.Get(rp.alogkey)
-									if res.Exists() {
+									r2 := res.Get(rp.alogkey)
+									if r2.Exists() {
 										if k > 0 {
 											jsons = append(jsons, ',')
 										}
-										raw := res.Raw
+										raw := r2.Raw
 										if len(raw) == 0 {
-											raw = res.String()
+											raw = r2.String()
 										}
 										jsons = append(jsons, []byte(raw)...)
-										indexes = append(indexes, res.Index)
+										indexes = append(indexes, r2.Index)
 										k++
 									}
 								}

--- a/gjson.go
+++ b/gjson.go
@@ -75,7 +75,7 @@ type Result struct {
 }
 
 // String returns a string representation of the value.
-func (t Result) String() string {
+func (t *Result) String() string {
 	switch t.Type {
 	default:
 		return ""
@@ -106,7 +106,7 @@ func (t Result) String() string {
 }
 
 // Bool returns an boolean representation.
-func (t Result) Bool() bool {
+func (t *Result) Bool() bool {
 	switch t.Type {
 	default:
 		return false
@@ -121,7 +121,7 @@ func (t Result) Bool() bool {
 }
 
 // Int returns an integer representation.
-func (t Result) Int() int64 {
+func (t *Result) Int() int64 {
 	switch t.Type {
 	default:
 		return 0
@@ -147,7 +147,7 @@ func (t Result) Int() int64 {
 }
 
 // Uint returns an unsigned integer representation.
-func (t Result) Uint() uint64 {
+func (t *Result) Uint() uint64 {
 	switch t.Type {
 	default:
 		return 0
@@ -173,7 +173,7 @@ func (t Result) Uint() uint64 {
 }
 
 // Float returns an float64 representation.
-func (t Result) Float() float64 {
+func (t *Result) Float() float64 {
 	switch t.Type {
 	default:
 		return 0
@@ -188,7 +188,7 @@ func (t Result) Float() float64 {
 }
 
 // Time returns a time.Time representation.
-func (t Result) Time() time.Time {
+func (t *Result) Time() time.Time {
 	res, _ := time.Parse(time.RFC3339, t.String())
 	return res
 }
@@ -198,29 +198,29 @@ func (t Result) Time() time.Time {
 // array will be returned.
 // If the result is not a JSON array, the return value will be an
 // array containing one result.
-func (t Result) Array() []Result {
+func (t *Result) Array() []*Result {
 	if t.Type == Null {
-		return []Result{}
+		return []*Result{}
 	}
 	if !t.IsArray() {
-		return []Result{t}
+		return []*Result{t}
 	}
 	r := t.arrayOrMap('[', false)
 	return r.a
 }
 
 // IsObject returns true if the result value is a JSON object.
-func (t Result) IsObject() bool {
+func (t *Result) IsObject() bool {
 	return t.Type == JSON && len(t.Raw) > 0 && t.Raw[0] == '{'
 }
 
 // IsArray returns true if the result value is a JSON array.
-func (t Result) IsArray() bool {
+func (t *Result) IsArray() bool {
 	return t.Type == JSON && len(t.Raw) > 0 && t.Raw[0] == '['
 }
 
 // IsBool returns true if the result value is a JSON boolean.
-func (t Result) IsBool() bool {
+func (t *Result) IsBool() bool {
 	return t.Type == True || t.Type == False
 }
 
@@ -230,18 +230,19 @@ func (t Result) IsBool() bool {
 // value of each item. If the result is an Array, the iterator will only pass
 // the value of each item. If the result is not a JSON array or object, the
 // iterator will pass back one value equal to the result.
-func (t Result) ForEach(iterator func(key, value Result) bool) {
+func (t *Result) ForEach(iterator func(key, value *Result) bool) {
 	if !t.Exists() {
 		return
 	}
 	if t.Type != JSON {
-		iterator(Result{}, t)
+		iterator(&Result{}, t)
 		return
 	}
 	json := t.Raw
 	var obj bool
 	var i int
-	var key, value Result
+	var value *Result
+	var key Result
 	for ; i < len(json); i++ {
 		if json[i] == '{' {
 			i++
@@ -263,6 +264,8 @@ func (t Result) ForEach(iterator func(key, value Result) bool) {
 	var ok bool
 	var idx int
 	for ; i < len(json); i++ {
+		iKey := &Result{}
+		*iKey = key
 		if obj {
 			if json[i] != '"' {
 				continue
@@ -273,14 +276,16 @@ func (t Result) ForEach(iterator func(key, value Result) bool) {
 				return
 			}
 			if vesc {
-				key.Str = unescape(str[1 : len(str)-1])
+				iKey.Str = unescape(str[1 : len(str)-1])
 			} else {
-				key.Str = str[1 : len(str)-1]
+				iKey.Str = str[1 : len(str)-1]
 			}
-			key.Raw = str
+			iKey.Raw = str
+			iKey.Index = s + t.Index
 			key.Index = s + t.Index
 		} else {
 			key.Num += 1
+			iKey.Num += 1
 		}
 		for ; i < len(json); i++ {
 			if json[i] <= ' ' || json[i] == ',' || json[i] == ':' {
@@ -300,7 +305,7 @@ func (t Result) ForEach(iterator func(key, value Result) bool) {
 		} else {
 			value.Index = s + t.Index
 		}
-		if !iterator(key, value) {
+		if !iterator(iKey, value) {
 			return
 		}
 		idx++
@@ -309,9 +314,9 @@ func (t Result) ForEach(iterator func(key, value Result) bool) {
 
 // Map returns back a map of values. The result should be a JSON object.
 // If the result is not a JSON object, the return value will be an empty map.
-func (t Result) Map() map[string]Result {
+func (t *Result) Map() map[string]*Result {
 	if t.Type != JSON {
-		return map[string]Result{}
+		return map[string]*Result{}
 	}
 	r := t.arrayOrMap('{', false)
 	return r.o
@@ -319,7 +324,7 @@ func (t Result) Map() map[string]Result {
 
 // Get searches result for the specified path.
 // The result should be a JSON array or object.
-func (t Result) Get(path string) Result {
+func (t *Result) Get(path string) *Result {
 	r := Get(t.Raw, path)
 	if len(r.Indexes) > 0 {
 		for i := 0; i < len(r.Indexes); i++ {
@@ -332,17 +337,17 @@ func (t Result) Get(path string) Result {
 }
 
 type arrayOrMapResult struct {
-	a  []Result
+	a  []*Result
 	ai []interface{}
-	o  map[string]Result
+	o  map[string]*Result
 	oi map[string]interface{}
 	vc byte
 }
 
-func (t Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
-	var json = t.Raw
+func (t *Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
+	json := t.Raw
 	var i int
-	var value Result
+	var value *Result
 	var count int
 	var key Result
 	if vc == 0 {
@@ -372,15 +377,16 @@ func (t Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
 		if valueize {
 			r.oi = make(map[string]interface{})
 		} else {
-			r.o = make(map[string]Result)
+			r.o = make(map[string]*Result)
 		}
 	} else {
 		if valueize {
 			r.ai = make([]interface{}, 0)
 		} else {
-			r.a = make([]Result, 0)
+			r.a = make([]*Result, 0)
 		}
 	}
+	value = &Result{}
 	for ; i < len(json); i++ {
 		if json[i] <= ' ' {
 			continue
@@ -425,15 +431,17 @@ func (t Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
 
 		if r.vc == '{' {
 			if count%2 == 0 {
-				key = value
+				key = *value
 			} else {
 				if valueize {
 					if _, ok := r.oi[key.Str]; !ok {
 						r.oi[key.Str] = value.Value()
+						value = &Result{}
 					}
 				} else {
 					if _, ok := r.o[key.Str]; !ok {
 						r.o[key.Str] = value
+						value = &Result{}
 					}
 				}
 			}
@@ -441,8 +449,10 @@ func (t Result) arrayOrMap(vc byte, valueize bool) (r arrayOrMapResult) {
 		} else {
 			if valueize {
 				r.ai = append(r.ai, value.Value())
+				value = &Result{}
 			} else {
 				r.a = append(r.a, value)
+				value = &Result{}
 			}
 		}
 	}
@@ -467,10 +477,10 @@ end:
 // Invalid json will not panic, but it may return back unexpected results.
 // If you are consuming JSON from an unpredictable source then you may want to
 // use the Valid function first.
-func Parse(json string) Result {
+func Parse(json string) *Result {
 	var value Result
 	value.Parse(json)
-	return value
+	return &value
 }
 
 // Clear for pooling
@@ -539,8 +549,10 @@ func (value *Result) Parse(json string) {
 
 // ParseBytes parses the json and returns a result.
 // If working with bytes, this method preferred over Parse(string(data))
-func ParseBytes(json []byte) Result {
-	return Parse(string(json))
+func ParseBytes(json []byte) *Result {
+	var value Result
+	value.ParseBytes(json)
+	return &value
 }
 
 func squash(json string) string {
@@ -677,7 +689,7 @@ func tostr(json string) (raw string, str string) {
 //	 if gjson.Get(json, "name.last").Exists(){
 //			println("value exists")
 //	 }
-func (t Result) Exists() bool {
+func (t *Result) Exists() bool {
 	return t.Type != Null || len(t.Raw) != 0
 }
 
@@ -690,7 +702,7 @@ func (t Result) Exists() bool {
 //	nil, for JSON null
 //	map[string]interface{}, for JSON objects
 //	[]interface{}, for JSON arrays
-func (t Result) Value() interface{} {
+func (t *Result) Value() interface{} {
 	if t.Type == String {
 		return t.Str
 	}
@@ -715,7 +727,7 @@ func (t Result) Value() interface{} {
 }
 
 func parseString(json string, i int) (int, string, bool, bool) {
-	var s = i
+	s := i
 	for ; i < len(json); i++ {
 		if json[i] > '\\' {
 			continue
@@ -753,7 +765,7 @@ func parseString(json string, i int) (int, string, bool, bool) {
 }
 
 func parseNumber(json string, i int) (int, string) {
-	var s = i
+	s := i
 	i++
 	for ; i < len(json); i++ {
 		if json[i] <= ' ' || json[i] == ',' || json[i] == ']' ||
@@ -765,7 +777,7 @@ func parseNumber(json string, i int) (int, string) {
 }
 
 func parseLiteral(json string, i int) (int, string) {
-	var s = i
+	s := i
 	i++
 	for ; i < len(json); i++ {
 		if json[i] < 'a' || json[i] > 'z' {
@@ -822,8 +834,7 @@ func parseArrayPath(path string) (r arrayPathResult) {
 				} else if path[1] == '[' || path[1] == '(' {
 					// query
 					r.query.on = true
-					qpath, op, value, _, fi, vesc, ok :=
-						parseQuery(path[i:])
+					qpath, op, value, _, fi, vesc, ok := parseQuery(path[i:])
 					if !ok {
 						// bad query, end now
 						break
@@ -1230,7 +1241,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				// this is slightly different from getting s string value
 				// because we don't need the outer quotes.
 				i++
-				var s = i
+				s := i
 				for ; i < len(c.json); i++ {
 					if c.json[i] > '\\' {
 						continue
@@ -1386,7 +1397,7 @@ func matchLimit(str, pattern string) bool {
 	return matched
 }
 
-func falseish(t Result) bool {
+func falseish(t *Result) bool {
 	switch t.Type {
 	case Null:
 		return true
@@ -1405,7 +1416,7 @@ func falseish(t Result) bool {
 	}
 }
 
-func trueish(t Result) bool {
+func trueish(t *Result) bool {
 	switch t.Type {
 	case True:
 		return true
@@ -1422,11 +1433,11 @@ func trueish(t Result) bool {
 	}
 }
 
-func nullish(t Result) bool {
+func nullish(t *Result) bool {
 	return t.Type == Null
 }
 
-func queryMatches(rp *arrayPathResult, value Result) bool {
+func queryMatches(rp *arrayPathResult, value *Result) bool {
 	rpv := rp.query.value
 	if len(rpv) > 0 {
 		if rpv[0] == '~' {
@@ -1446,13 +1457,13 @@ func queryMatches(rp *arrayPathResult, value Result) bool {
 			if ok {
 				rpv = "true"
 				if ish {
-					value = Result{Type: True}
+					value = &Result{Type: True}
 				} else {
-					value = Result{Type: False}
+					value = &Result{Type: False}
 				}
 			} else {
 				rpv = ""
-				value = Result{}
+				value = &Result{}
 			}
 		}
 	}
@@ -1527,6 +1538,13 @@ func queryMatches(rp *arrayPathResult, value Result) bool {
 	}
 	return false
 }
+
+func newParseContext() *parseContext {
+	return &parseContext{
+		value: &Result{},
+	}
+}
+
 func parseArray(c *parseContext, i int, path string) (int, bool) {
 	var pmatch, vesc, ok, hit bool
 	var val string
@@ -1549,24 +1567,24 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 		c.piped = true
 	}
 
-	procQuery := func(qval Result) bool {
+	procQuery := func(qval *Result) bool {
 		if rp.query.all {
 			if len(multires) == 0 {
 				multires = append(multires, '[')
 			}
 		}
-		var tmp parseContext
-		tmp.value = qval
-		fillIndex(c.json, &tmp)
+		tmp := newParseContext()
+		*tmp.value = *qval
+		fillIndex(c.json, tmp)
 		parentIndex := tmp.value.Index
-		var res Result
+		res := &Result{}
 		if qval.Type == JSON {
 			res = qval.Get(rp.query.path)
 		} else {
 			if rp.query.path != "" {
 				return false
 			}
-			res = qval
+			*res = *qval
 		}
 		if queryMatches(&rp, res) {
 			if rp.more {
@@ -1636,7 +1654,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					}
 					qval.Raw = val
 					qval.Type = String
-					if procQuery(qval) {
+					if procQuery(&qval) {
 						return i, true
 					}
 				} else if hit {
@@ -1664,7 +1682,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				} else {
 					i, val = parseSquash(c.json, i)
 					if rp.query.on {
-						if procQuery(Result{Raw: val, Type: JSON}) {
+						if procQuery(&Result{Raw: val, Type: JSON}) {
 							return i, true
 						}
 					} else if hit {
@@ -1688,7 +1706,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				} else {
 					i, val = parseSquash(c.json, i)
 					if rp.query.on {
-						if procQuery(Result{Raw: val, Type: JSON}) {
+						if procQuery(&Result{Raw: val, Type: JSON}) {
 							return i, true
 						}
 					} else if hit {
@@ -1718,7 +1736,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					case 'f':
 						qval.Type = False
 					}
-					if procQuery(qval) {
+					if procQuery(&qval) {
 						return i, true
 					}
 				} else if hit {
@@ -1746,8 +1764,8 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 							c.pipe = right
 							c.piped = true
 						}
-						var indexes = make([]int, 0, 64)
-						var jsons = make([]byte, 0, 64)
+						indexes := make([]int, 0, 64)
+						jsons := make([]byte, 0, 64)
 						jsons = append(jsons, '[')
 						for j, k := 0, 0; j < len(alog); j++ {
 							idx := alog[j]
@@ -1796,13 +1814,13 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				}
 				if !c.value.Exists() {
 					if len(multires) > 0 {
-						c.value = Result{
+						c.value = &Result{
 							Raw:     string(append(multires, ']')),
 							Type:    JSON,
 							Indexes: queryIndexes,
 						}
 					} else if rp.query.all {
-						c.value = Result{
+						c.value = &Result{
 							Raw:  "[]",
 							Type: JSON,
 						}
@@ -1817,7 +1835,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					qval.Raw = val
 					qval.Type = Number
 					qval.Num, _ = strconv.ParseFloat(val, 64)
-					if procQuery(qval) {
+					if procQuery(&qval) {
 						return i, true
 					}
 				} else if hit {
@@ -1921,8 +1939,8 @@ func splitPossiblePipe(path string) (left, right string, ok bool) {
 // ForEachLine iterates through lines of JSON as specified by the JSON Lines
 // format (http://jsonlines.org/).
 // Each line is returned as a GJSON Result.
-func ForEachLine(json string, iterator func(line Result) bool) {
-	var res Result
+func ForEachLine(json string, iterator func(line *Result) bool) {
+	var res *Result
 	var i int
 	for {
 		i, res, _ = parseAny(json, i, true)
@@ -2109,7 +2127,7 @@ func AppendJSONString(dst []byte, s string) []byte {
 
 type parseContext struct {
 	json  string
-	value Result
+	value *Result
 	pipe  string
 	piped bool
 	calcd bool
@@ -2149,7 +2167,7 @@ type parseContext struct {
 // Invalid json will not panic, but it may return back unexpected results.
 // If you are consuming JSON from an unpredictable source then you may want to
 // use the Valid function first.
-func Get(json, path string) Result {
+func Get(json, path string) *Result {
 	if len(path) > 1 {
 		if (path[0] == '@' && !DisableModifiers) || path[0] == '!' {
 			// possible modifier
@@ -2220,7 +2238,7 @@ func Get(json, path string) Result {
 						}
 					}
 					b = append(b, kind+2)
-					var res Result
+					res := &Result{}
 					res.Raw = string(b)
 					res.Type = JSON
 					if len(path) > 0 {
@@ -2233,7 +2251,7 @@ func Get(json, path string) Result {
 		}
 	}
 	var i int
-	var c = &parseContext{json: json}
+	c := &parseContext{json: json, value: &Result{}}
 	if len(path) >= 2 && path[0] == '.' && path[1] == '.' {
 		c.lines = true
 		parseArray(c, 0, path[2:])
@@ -2262,7 +2280,7 @@ func Get(json, path string) Result {
 
 // GetBytes searches json for the specified path.
 // If working with bytes, this method preferred over Get(string(data), path)
-func GetBytes(json []byte, path string) Result {
+func GetBytes(json []byte, path string) *Result {
 	return getBytes(json, path)
 }
 
@@ -2274,7 +2292,7 @@ func runeit(json string) rune {
 
 // unescape unescapes a string
 func unescape(json string) string {
-	var str = make([]byte, 0, len(json))
+	str := make([]byte, 0, len(json))
 	for i := 0; i < len(json); i++ {
 		switch {
 		default:
@@ -2336,7 +2354,7 @@ func unescape(json string) string {
 // The order when comparing two different type is:
 //
 //	Null < False < Number < String < True < JSON
-func (t Result) Less(token Result, caseSensitive bool) bool {
+func (t *Result) Less(token *Result, caseSensitive bool) bool {
 	if t.Type < token.Type {
 		return true
 	}
@@ -2395,7 +2413,7 @@ func stringLessInsensitive(a, b string) bool {
 // parseAny parses the next value from a json string.
 // A Result is returned when the hit param is set.
 // The return values are (i int, res Result, ok bool)
-func parseAny(json string, i int, hit bool) (int, Result, bool) {
+func parseAny(json string, i int, hit bool) (int, *Result, bool) {
 	var res Result
 	var val string
 	for ; i < len(json); i++ {
@@ -2405,9 +2423,9 @@ func parseAny(json string, i int, hit bool) (int, Result, bool) {
 				res.Raw = val
 				res.Type = JSON
 			}
-			var tmp parseContext
-			tmp.value = res
-			fillIndex(json, &tmp)
+			tmp := newParseContext()
+			tmp.value = &res
+			fillIndex(json, tmp)
 			return i, tmp.value, true
 		}
 		if json[i] <= ' ' {
@@ -2421,7 +2439,7 @@ func parseAny(json string, i int, hit bool) (int, Result, bool) {
 			var ok bool
 			i, val, vesc, ok = parseString(json, i)
 			if !ok {
-				return i, res, false
+				return i, &res, false
 			}
 			if hit {
 				res.Type = String
@@ -2432,7 +2450,7 @@ func parseAny(json string, i int, hit bool) (int, Result, bool) {
 					res.Str = val[1 : len(val)-1]
 				}
 			}
-			return i, res, true
+			return i, &res, true
 		case 'n':
 			if i+1 < len(json) && json[i+1] != 'u' {
 				num = true
@@ -2450,7 +2468,7 @@ func parseAny(json string, i int, hit bool) (int, Result, bool) {
 				case 'f':
 					res.Type = False
 				}
-				return i, res, true
+				return i, &res, true
 			}
 		case '+', '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
 			'i', 'I', 'N':
@@ -2463,18 +2481,18 @@ func parseAny(json string, i int, hit bool) (int, Result, bool) {
 				res.Type = Number
 				res.Num, _ = strconv.ParseFloat(val, 64)
 			}
-			return i, res, true
+			return i, &res, true
 		}
 
 	}
-	return i, res, false
+	return i, &res, false
 }
 
 // GetMany searches json for the multiple paths.
 // The return value is a Result array where the number of items
 // will be equal to the number of input paths.
-func GetMany(json string, path ...string) []Result {
-	res := make([]Result, len(path))
+func GetMany(json string, path ...string) []*Result {
+	res := make([]*Result, len(path))
 	for i, path := range path {
 		res[i] = Get(json, path)
 	}
@@ -2484,8 +2502,8 @@ func GetMany(json string, path ...string) []Result {
 // GetManyBytes searches json for the multiple paths.
 // The return value is a Result array where the number of items
 // will be equal to the number of input paths.
-func GetManyBytes(json []byte, path ...string) []Result {
-	res := make([]Result, len(path))
+func GetManyBytes(json []byte, path ...string) []*Result {
+	res := make([]*Result, len(path))
 	for i, path := range path {
 		res[i] = GetBytes(json, path)
 	}
@@ -2515,6 +2533,7 @@ func validpayload(data []byte, i int) (outi int, ok bool) {
 	}
 	return i, false
 }
+
 func validany(data []byte, i int) (outi int, ok bool) {
 	for ; i < len(data); i++ {
 		switch data[i] {
@@ -2540,6 +2559,7 @@ func validany(data []byte, i int) (outi int, ok bool) {
 	}
 	return i, false
 }
+
 func validobject(data []byte, i int) (outi int, ok bool) {
 	for ; i < len(data); i++ {
 		switch data[i] {
@@ -2582,6 +2602,7 @@ func validobject(data []byte, i int) (outi int, ok bool) {
 	}
 	return i, false
 }
+
 func validcolon(data []byte, i int) (outi int, ok bool) {
 	for ; i < len(data); i++ {
 		switch data[i] {
@@ -2595,6 +2616,7 @@ func validcolon(data []byte, i int) (outi int, ok bool) {
 	}
 	return i, false
 }
+
 func validcomma(data []byte, i int, end byte) (outi int, ok bool) {
 	for ; i < len(data); i++ {
 		switch data[i] {
@@ -2610,6 +2632,7 @@ func validcomma(data []byte, i int, end byte) (outi int, ok bool) {
 	}
 	return i, false
 }
+
 func validarray(data []byte, i int) (outi int, ok bool) {
 	for ; i < len(data); i++ {
 		switch data[i] {
@@ -2633,6 +2656,7 @@ func validarray(data []byte, i int) (outi int, ok bool) {
 	}
 	return i, false
 }
+
 func validstring(data []byte, i int) (outi int, ok bool) {
 	for ; i < len(data); i++ {
 		if data[i] < ' ' {
@@ -2665,6 +2689,7 @@ func validstring(data []byte, i int) (outi int, ok bool) {
 	}
 	return i, false
 }
+
 func validnumber(data []byte, i int) (outi int, ok bool) {
 	i--
 	// sign
@@ -2747,6 +2772,7 @@ func validtrue(data []byte, i int) (outi int, ok bool) {
 	}
 	return i, false
 }
+
 func validfalse(data []byte, i int) (outi int, ok bool) {
 	if i+4 <= len(data) && data[i] == 'a' && data[i+1] == 'l' &&
 		data[i+2] == 's' && data[i+3] == 'e' {
@@ -2754,6 +2780,7 @@ func validfalse(data []byte, i int) (outi int, ok bool) {
 	}
 	return i, false
 }
+
 func validnull(data []byte, i int) (outi int, ok bool) {
 	if i+3 <= len(data) && data[i] == 'u' && data[i+1] == 'l' &&
 		data[i+2] == 'l' {
@@ -2995,7 +3022,7 @@ func cleanWS(s string) string {
 func modPretty(json, arg string) string {
 	if len(arg) > 0 {
 		opts := *pretty.DefaultOptions
-		Parse(arg).ForEach(func(key, value Result) bool {
+		Parse(arg).ForEach(func(key, value *Result) bool {
 			switch key.String() {
 			case "sortKeys":
 				opts.SortKeys = value.Bool()
@@ -3027,8 +3054,8 @@ func modUgly(json, arg string) string {
 func modReverse(json, arg string) string {
 	res := Parse(json)
 	if res.IsArray() {
-		var values []Result
-		res.ForEach(func(_, value Result) bool {
+		var values []*Result
+		res.ForEach(func(_, value *Result) bool {
 			values = append(values, value)
 			return true
 		})
@@ -3044,8 +3071,8 @@ func modReverse(json, arg string) string {
 		return bytesString(out)
 	}
 	if res.IsObject() {
-		var keyValues []Result
-		res.ForEach(func(key, value Result) bool {
+		var keyValues []*Result
+		res.ForEach(func(key, value *Result) bool {
 			keyValues = append(keyValues, key, value)
 			return true
 		})
@@ -3081,7 +3108,7 @@ func modFlatten(json, arg string) string {
 	}
 	var deep bool
 	if arg != "" {
-		Parse(arg).ForEach(func(key, value Result) bool {
+		Parse(arg).ForEach(func(key, value *Result) bool {
 			if key.String() == "deep" {
 				deep = value.Bool()
 			}
@@ -3091,7 +3118,7 @@ func modFlatten(json, arg string) string {
 	var out []byte
 	out = append(out, '[')
 	var idx int
-	res.ForEach(func(_, value Result) bool {
+	res.ForEach(func(_, value *Result) bool {
 		var raw string
 		if value.IsArray() {
 			if deep {
@@ -3128,7 +3155,7 @@ func modKeys(json, arg string) string {
 	var out strings.Builder
 	out.WriteByte('[')
 	var i int
-	v.ForEach(func(key, _ Result) bool {
+	v.ForEach(func(key, _ *Result) bool {
 		if i > 0 {
 			out.WriteByte(',')
 		}
@@ -3158,7 +3185,7 @@ func modValues(json, arg string) string {
 	var out strings.Builder
 	out.WriteByte('[')
 	var i int
-	v.ForEach(func(_, value Result) bool {
+	v.ForEach(func(_, value *Result) bool {
 		if i > 0 {
 			out.WriteByte(',')
 		}
@@ -3190,7 +3217,7 @@ func modJoin(json, arg string) string {
 	}
 	var preserve bool
 	if arg != "" {
-		Parse(arg).ForEach(func(key, value Result) bool {
+		Parse(arg).ForEach(func(key, value *Result) bool {
 			if key.String() == "preserve" {
 				preserve = value.Bool()
 			}
@@ -3202,7 +3229,7 @@ func modJoin(json, arg string) string {
 	if preserve {
 		// Preserve duplicate keys.
 		var idx int
-		res.ForEach(func(_, value Result) bool {
+		res.ForEach(func(_, value *Result) bool {
 			if !value.IsObject() {
 				return true
 			}
@@ -3215,13 +3242,13 @@ func modJoin(json, arg string) string {
 		})
 	} else {
 		// Deduplicate keys and generate an object with stable ordering.
-		var keys []Result
-		kvals := make(map[string]Result)
-		res.ForEach(func(_, value Result) bool {
+		var keys []*Result
+		kvals := make(map[string]*Result)
+		res.ForEach(func(_, value *Result) bool {
 			if !value.IsObject() {
 				return true
 			}
-			value.ForEach(func(key, value Result) bool {
+			value.ForEach(func(key, value *Result) bool {
 				k := key.String()
 				if _, ok := kvals[k]; !ok {
 					keys = append(keys, key)
@@ -3276,12 +3303,12 @@ func modGroup(json, arg string) string {
 		return ""
 	}
 	var all [][]byte
-	res.ForEach(func(key, value Result) bool {
+	res.ForEach(func(key, value *Result) bool {
 		if !value.IsArray() {
 			return true
 		}
 		var idx int
-		value.ForEach(func(_, value Result) bool {
+		value.ForEach(func(_, value *Result) bool {
 			if idx == len(all) {
 				all = append(all, []byte{})
 			}
@@ -3321,8 +3348,8 @@ type sliceHeader struct {
 // getBytes casts the input json bytes to a string and safely returns the
 // results as uniquely allocated data. This operation is intended to minimize
 // copies and allocations for the large json string->[]byte.
-func getBytes(json []byte, path string) Result {
-	var result Result
+func getBytes(json []byte, path string) *Result {
+	var result *Result
 	if json != nil {
 		// unsafe cast to string
 		result = Get(*(*string)(unsafe.Pointer(&json)), path)
@@ -3453,12 +3480,12 @@ func revSquash(json string) string {
 // Returns an empty string if the paths cannot be determined, which can happen
 // when the Result came from a path that contained a multipath, modifier,
 // or a nested query.
-func (t Result) Paths(json string) []string {
+func (t *Result) Paths(json string) []string {
 	if len(t.Indexes) == 0 {
 		return nil
 	}
 	paths := make([]string, 0, len(t.Indexes))
-	t.ForEach(func(_, value Result) bool {
+	t.ForEach(func(_, value *Result) bool {
 		paths = append(paths, value.Path(json))
 		return true
 	})
@@ -3482,7 +3509,7 @@ func (t Result) Paths(json string) []string {
 // Returns an empty string if the paths cannot be determined, which can happen
 // when the Result came from a path that contained a multipath, modifier,
 // or a nested query.
-func (t Result) Path(json string) string {
+func (t *Result) Path(json string) string {
 	var path []byte
 	var comps []string // raw components
 	i := t.Index - 1
@@ -3604,12 +3631,12 @@ func Escape(comp string) string {
 	return comp
 }
 
-func parseRecursiveDescent(all []Result, parent Result, path string) []Result {
+func parseRecursiveDescent(all []*Result, parent *Result, path string) []*Result {
 	if res := parent.Get(path); res.Exists() {
 		all = append(all, res)
 	}
 	if parent.IsArray() || parent.IsObject() {
-		parent.ForEach(func(_, val Result) bool {
+		parent.ForEach(func(_, val *Result) bool {
 			all = parseRecursiveDescent(all, val, path)
 			return true
 		})

--- a/gjson.go
+++ b/gjson.go
@@ -1230,34 +1230,34 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 		c.pipe = rp.pipe
 		c.piped = true
 	}
-	for i < len(*c.json) {
-		for ; i < len(*c.json); i++ {
-			if (*c.json)[i] == '"' {
+	for i < len(c.json) {
+		for ; i < len(c.json); i++ {
+			if c.json[i] == '"' {
 				// parse_key_string
 				// this is slightly different from getting s string value
 				// because we don't need the outer quotes.
 				i++
 				s := i
-				for ; i < len(*c.json); i++ {
-					if (*c.json)[i] > '\\' {
+				for ; i < len(c.json); i++ {
+					if c.json[i] > '\\' {
 						continue
 					}
-					if (*c.json)[i] == '"' {
-						i, key, kesc, ok = i+1, (*c.json)[s:i], false, true
+					if c.json[i] == '"' {
+						i, key, kesc, ok = i+1, c.json[s:i], false, true
 						goto parse_key_string_done
 					}
-					if (*c.json)[i] == '\\' {
+					if c.json[i] == '\\' {
 						i++
-						for ; i < len((*c.json)); i++ {
-							if (*c.json)[i] > '\\' {
+						for ; i < len(c.json); i++ {
+							if c.json[i] > '\\' {
 								continue
 							}
-							if (*c.json)[i] == '"' {
+							if c.json[i] == '"' {
 								// look for an escaped slash
-								if (*c.json)[i-1] == '\\' {
+								if c.json[i-1] == '\\' {
 									n := 0
 									for j := i - 2; j > 0; j-- {
-										if (*c.json)[j] != '\\' {
+										if c.json[j] != '\\' {
 											break
 										}
 										n++
@@ -1266,18 +1266,18 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 										continue
 									}
 								}
-								i, key, kesc, ok = i+1, (*c.json)[s:i], true, true
+								i, key, kesc, ok = i+1, c.json[s:i], true, true
 								goto parse_key_string_done
 							}
 						}
 						break
 					}
 				}
-				key, kesc, ok = (*c.json)[s:], false, false
+				key, kesc, ok = c.json[s:], false, false
 			parse_key_string_done:
 				break
 			}
-			if (*c.json)[i] == '}' {
+			if c.json[i] == '}' {
 				return i + 1, false
 			}
 		}
@@ -1298,14 +1298,14 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 			}
 		}
 		hit = pmatch && !rp.more
-		for ; i < len((*c.json)); i++ {
+		for ; i < len(c.json); i++ {
 			var num bool
-			switch (*c.json)[i] {
+			switch c.json[i] {
 			default:
 				continue
 			case '"':
 				i++
-				i, val, vesc, ok = parseString((*c.json), i)
+				i, val, vesc, ok = parseString(c.json, i)
 				if !ok {
 					return i, false
 				}
@@ -1326,7 +1326,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 						return i, true
 					}
 				} else {
-					i, val = parseSquash((*c.json), i)
+					i, val = parseSquash(c.json, i)
 					if hit {
 						c.value.Raw = val
 						c.value.Type = JSON
@@ -1340,7 +1340,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 						return i, true
 					}
 				} else {
-					i, val = parseSquash((*c.json), i)
+					i, val = parseSquash(c.json, i)
 					if hit {
 						c.value.Raw = val
 						c.value.Type = JSON
@@ -1348,14 +1348,14 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 					}
 				}
 			case 'n':
-				if i+1 < len((*c.json)) && (*c.json)[i+1] != 'u' {
+				if i+1 < len(c.json) && c.json[i+1] != 'u' {
 					num = true
 					break
 				}
 				fallthrough
 			case 't', 'f':
-				vc := (*c.json)[i]
-				i, val = parseLiteral((*c.json), i)
+				vc := c.json[i]
+				i, val = parseLiteral(c.json, i)
 				if hit {
 					c.value.Raw = val
 					switch vc {
@@ -1371,7 +1371,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				num = true
 			}
 			if num {
-				i, val = parseNumber((*c.json), i)
+				i, val = parseNumber(c.json, i)
 				if hit {
 					c.value.Raw = val
 					c.value.Type = Number
@@ -1565,7 +1565,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 		}
 		tmp := parseContext{value: &Result{}}
 		*tmp.value = *qval
-		fillIndex((*c.json), &tmp)
+		fillIndex(c.json, &tmp)
 		parentIndex := tmp.value.Index
 		res := &Result{}
 		if qval.Type == JSON {
@@ -1607,7 +1607,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 		}
 		return false
 	}
-	for i < len((*c.json))+1 {
+	for i < len(c.json)+1 {
 		if !rp.arrch {
 			pmatch = partidx == h
 			hit = pmatch && !rp.more
@@ -1618,12 +1618,12 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 		}
 		for ; ; i++ {
 			var ch byte
-			if i > len((*c.json)) {
+			if i > len(c.json) {
 				break
-			} else if i == len((*c.json)) {
+			} else if i == len(c.json) {
 				ch = ']'
 			} else {
-				ch = (*c.json)[i]
+				ch = c.json[i]
 			}
 			var num bool
 			switch ch {
@@ -1631,7 +1631,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				continue
 			case '"':
 				i++
-				i, val, vesc, ok = parseString((*c.json), i)
+				i, val, vesc, ok = parseString(c.json, i)
 				if !ok {
 					return i, false
 				}
@@ -1670,7 +1670,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 						return i, true
 					}
 				} else {
-					i, val = parseSquash((*c.json), i)
+					i, val = parseSquash(c.json, i)
 					if rp.query.on {
 						if procQuery(&Result{Raw: val, Type: JSON}) {
 							return i, true
@@ -1694,7 +1694,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 						return i, true
 					}
 				} else {
-					i, val = parseSquash((*c.json), i)
+					i, val = parseSquash(c.json, i)
 					if rp.query.on {
 						if procQuery(&Result{Raw: val, Type: JSON}) {
 							return i, true
@@ -1709,14 +1709,14 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					}
 				}
 			case 'n':
-				if i+1 < len((*c.json)) && (*c.json)[i+1] != 'u' {
+				if i+1 < len(c.json) && c.json[i+1] != 'u' {
 					num = true
 					break
 				}
 				fallthrough
 			case 't', 'f':
-				vc := (*c.json)[i]
-				i, val = parseLiteral((*c.json), i)
+				vc := c.json[i]
+				i, val = parseLiteral(c.json, i)
 				if rp.query.on {
 					var qval Result
 					qval.Raw = val
@@ -1759,16 +1759,16 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 						jsons = append(jsons, '[')
 						for j, k := 0, 0; j < len(alog); j++ {
 							idx := alog[j]
-							for idx < len((*c.json)) {
-								switch (*c.json)[idx] {
+							for idx < len(c.json) {
+								switch c.json[idx] {
 								case ' ', '\t', '\r', '\n':
 									idx++
 									continue
 								}
 								break
 							}
-							if idx < len((*c.json)) && (*c.json)[idx] != ']' {
-								_, res, ok := parseAny((*c.json), idx, true)
+							if idx < len(c.json) && c.json[idx] != ']' {
+								_, res, ok := parseAny(c.json, idx, true)
 								if ok {
 									res := res.Get(rp.alogkey)
 									if res.Exists() {
@@ -1817,7 +1817,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				return i + 1, false
 			}
 			if num {
-				i, val = parseNumber((*c.json), i)
+				i, val = parseNumber(c.json, i)
 				if rp.query.on {
 					var qval Result
 					qval.Raw = val
@@ -2114,12 +2114,107 @@ func AppendJSONString(dst []byte, s string) []byte {
 }
 
 type parseContext struct {
-	json  *string
+	json  string
 	value *Result
 	pipe  string
 	piped bool
 	calcd bool
 	lines bool
+}
+
+func getDeepPathModifiers(json, path string) *Result {
+	// possible modifier
+	var ok bool
+	var npath string
+	var rjson string
+	if path[0] == '@' && !DisableModifiers {
+		npath, rjson, ok = execModifier(json, path)
+	} else if path[0] == '!' {
+		npath, rjson, ok = execStatic(json, path)
+	}
+	if ok {
+		path = npath
+		if len(path) > 0 && (path[0] == '|' || path[0] == '.') {
+			res := Get(rjson, path[1:])
+			res.Index = 0
+			res.Indexes = nil
+			return res
+		}
+		return Parse(rjson)
+	}
+	return nil
+}
+
+func getObjOrArray(json, path string) *Result {
+	// using a subselector path
+	kind := path[0]
+	var ok bool
+	var subs []subSelector
+	subs, path, ok = parseSubSelectors(path)
+	if ok {
+		if len(path) == 0 || (path[0] == '|' || path[0] == '.') {
+			var b []byte
+			b = append(b, kind)
+			var i int
+			for _, sub := range subs {
+				res := Get(json, sub.path)
+				if res.Exists() {
+					if i > 0 {
+						b = append(b, ',')
+					}
+					if kind == '{' {
+						if len(sub.name) > 0 {
+							if sub.name[0] == '"' && Valid(sub.name) {
+								b = append(b, sub.name...)
+							} else {
+								b = AppendJSONString(b, sub.name)
+							}
+						} else {
+							last := nameOfLast(sub.path)
+							if isSimpleName(last) {
+								b = AppendJSONString(b, last)
+							} else {
+								b = AppendJSONString(b, "_")
+							}
+						}
+						b = append(b, ':')
+					}
+					var raw string
+					if len(res.Raw) == 0 {
+						raw = res.String()
+						if len(raw) == 0 {
+							raw = "null"
+						}
+					} else {
+						raw = res.Raw
+					}
+					b = append(b, raw...)
+					i++
+				}
+			}
+			b = append(b, kind+2)
+			res := &Result{}
+			res.Raw = string(b)
+			res.Type = JSON
+			if len(path) > 0 {
+				res = res.Get(path[1:])
+			}
+			res.Index = 0
+			return res
+		}
+	}
+	return nil
+}
+
+// added for profiling
+func getDeepPath(json, path string) *Result {
+	if (path[0] == '@' && !DisableModifiers) || path[0] == '!' {
+		return getDeepPathModifiers(json, path)
+	}
+	if path[0] == '[' || path[0] == '{' {
+		return getObjOrArray(json, path)
+	}
+	return nil
 }
 
 // Get searches json for the specified path.
@@ -2157,101 +2252,25 @@ type parseContext struct {
 // use the Valid function first.
 func Get(json, path string) *Result {
 	if len(path) > 1 {
-		if (path[0] == '@' && !DisableModifiers) || path[0] == '!' {
-			// possible modifier
-			var ok bool
-			var npath string
-			var rjson string
-			if path[0] == '@' && !DisableModifiers {
-				npath, rjson, ok = execModifier(json, path)
-			} else if path[0] == '!' {
-				npath, rjson, ok = execStatic(json, path)
-			}
-			if ok {
-				path = npath
-				if len(path) > 0 && (path[0] == '|' || path[0] == '.') {
-					res := Get(rjson, path[1:])
-					res.Index = 0
-					res.Indexes = nil
-					return res
-				}
-				return Parse(rjson)
-			}
-		}
-		if path[0] == '[' || path[0] == '{' {
-			// using a subselector path
-			kind := path[0]
-			var ok bool
-			var subs []subSelector
-			subs, path, ok = parseSubSelectors(path)
-			if ok {
-				if len(path) == 0 || (path[0] == '|' || path[0] == '.') {
-					var b []byte
-					b = append(b, kind)
-					var i int
-					for _, sub := range subs {
-						res := Get(json, sub.path)
-						if res.Exists() {
-							if i > 0 {
-								b = append(b, ',')
-							}
-							if kind == '{' {
-								if len(sub.name) > 0 {
-									if sub.name[0] == '"' && Valid(sub.name) {
-										b = append(b, sub.name...)
-									} else {
-										b = AppendJSONString(b, sub.name)
-									}
-								} else {
-									last := nameOfLast(sub.path)
-									if isSimpleName(last) {
-										b = AppendJSONString(b, last)
-									} else {
-										b = AppendJSONString(b, "_")
-									}
-								}
-								b = append(b, ':')
-							}
-							var raw string
-							if len(res.Raw) == 0 {
-								raw = res.String()
-								if len(raw) == 0 {
-									raw = "null"
-								}
-							} else {
-								raw = res.Raw
-							}
-							b = append(b, raw...)
-							i++
-						}
-					}
-					b = append(b, kind+2)
-					res := &Result{}
-					res.Raw = string(b)
-					res.Type = JSON
-					if len(path) > 0 {
-						res = res.Get(path[1:])
-					}
-					res.Index = 0
-					return res
-				}
-			}
+		res := getDeepPath(json, path)
+		if res != nil {
+			return res
 		}
 	}
 	var i int
 	c := parseContext{value: &Result{}}
-	c.json = &json
+	c.json = json
 	if len(path) >= 2 && path[0] == '.' && path[1] == '.' {
 		c.lines = true
 		parseArray(&c, 0, path[2:])
 	} else {
-		for ; i < len((*c.json)); i++ {
-			if (*c.json)[i] == '{' {
+		for ; i < len(c.json); i++ {
+			if c.json[i] == '{' {
 				i++
 				parseObject(&c, i, path)
 				break
 			}
-			if (*c.json)[i] == '[' {
+			if c.json[i] == '[' {
 				i++
 				parseArray(&c, i, path)
 				break

--- a/gjson.go
+++ b/gjson.go
@@ -1563,8 +1563,8 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				multires = append(multires, '[')
 			}
 		}
-		tmp := parseContext{}
-		tmp.value = *qval
+		tmp := parseContext{value: &Result{}}
+		*tmp.value = *qval
 		fillIndex(c.json, &tmp)
 		parentIndex := tmp.value.Index
 		res := &Result{}
@@ -1601,7 +1601,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					queryIndexes = append(queryIndexes, res.Index+parentIndex)
 				}
 			} else {
-				c.value = *res
+				*c.value = *res
 				return true
 			}
 		}
@@ -2115,7 +2115,7 @@ func AppendJSONString(dst []byte, s string) []byte {
 
 type parseContext struct {
 	json  string
-	value Result
+	value *Result
 	pipe  string
 	piped bool
 	calcd bool
@@ -2239,7 +2239,7 @@ func Get(json, path string) *Result {
 		}
 	}
 	var i int
-	c := parseContext{value: Result{}}
+	c := parseContext{value: &Result{}}
 	c.json = json
 	if len(path) >= 2 && path[0] == '.' && path[1] == '.' {
 		c.lines = true
@@ -2264,7 +2264,7 @@ func Get(json, path string) *Result {
 		return res
 	}
 	fillIndex(json, &c)
-	return &c.value
+	return c.value
 }
 
 // GetBytes searches json for the specified path.
@@ -2413,9 +2413,10 @@ func parseAny(json string, i int, hit bool) (int, *Result, bool) {
 				res.Type = JSON
 			}
 			return func() (int, *Result, bool) {
-				tmp := parseContext{value: res}
+				tmp := parseContext{value: &Result{}}
+				*tmp.value = res
 				fillIndex(json, &tmp)
-				return i, &tmp.value, true
+				return i, tmp.value, true
 			}()
 		}
 		if json[i] <= ' ' {

--- a/gjson.go
+++ b/gjson.go
@@ -526,11 +526,12 @@ func (value *Result) Clear() {
 	if value.Indexes != nil {
 		value.Indexes = value.Indexes[:0]
 	}
-	if !value.nopool {
+	if !value.nopool && value.children != nil {
 		for _, v := range value.children {
 			v.Clear()
 			resultPool.Put(v)
 		}
+		value.children = value.children[:0]
 	}
 }
 

--- a/gjson.go
+++ b/gjson.go
@@ -1563,8 +1563,8 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				multires = append(multires, '[')
 			}
 		}
-		tmp := parseContext{value: &Result{}}
-		*tmp.value = *qval
+		tmp := parseContext{}
+		tmp.value = *qval
 		fillIndex(c.json, &tmp)
 		parentIndex := tmp.value.Index
 		res := &Result{}
@@ -1601,7 +1601,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					queryIndexes = append(queryIndexes, res.Index+parentIndex)
 				}
 			} else {
-				*c.value = *res
+				c.value = *res
 				return true
 			}
 		}
@@ -2115,7 +2115,7 @@ func AppendJSONString(dst []byte, s string) []byte {
 
 type parseContext struct {
 	json  string
-	value *Result
+	value Result
 	pipe  string
 	piped bool
 	calcd bool
@@ -2239,7 +2239,7 @@ func Get(json, path string) *Result {
 		}
 	}
 	var i int
-	c := parseContext{value: &Result{}}
+	c := parseContext{value: Result{}}
 	c.json = json
 	if len(path) >= 2 && path[0] == '.' && path[1] == '.' {
 		c.lines = true
@@ -2264,7 +2264,7 @@ func Get(json, path string) *Result {
 		return res
 	}
 	fillIndex(json, &c)
-	return c.value
+	return &c.value
 }
 
 // GetBytes searches json for the specified path.
@@ -2413,10 +2413,9 @@ func parseAny(json string, i int, hit bool) (int, *Result, bool) {
 				res.Type = JSON
 			}
 			return func() (int, *Result, bool) {
-				tmp := parseContext{value: &Result{}}
-				*tmp.value = res
+				tmp := parseContext{value: res}
 				fillIndex(json, &tmp)
-				return i, tmp.value, true
+				return i, &tmp.value, true
 			}()
 		}
 		if json[i] <= ' ' {

--- a/gjson.go
+++ b/gjson.go
@@ -328,7 +328,7 @@ func (t *Result) Get(path string) *Result {
 		}
 	}
 	var i int
-	c := parseContext{value: &Result{}}
+	c := parseContext{}
 	c.json = t.Raw
 	if len(path) >= 2 && path[0] == '.' && path[1] == '.' {
 		c.lines = true
@@ -1342,6 +1342,9 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 					return i, false
 				}
 				if hit {
+					if c.value == nil {
+						c.value = &Result{}
+					}
 					if vesc {
 						c.value.Str = unescape(val[1 : len(val)-1])
 					} else {
@@ -1360,6 +1363,9 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				} else {
 					i, val = parseSquash(c.json, i)
 					if hit {
+						if c.value == nil {
+							c.value = &Result{}
+						}
 						c.value.Raw = val
 						c.value.Type = JSON
 						return i, true
@@ -1374,6 +1380,9 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				} else {
 					i, val = parseSquash(c.json, i)
 					if hit {
+						if c.value == nil {
+							c.value = &Result{}
+						}
 						c.value.Raw = val
 						c.value.Type = JSON
 						return i, true
@@ -1389,6 +1398,9 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				vc := c.json[i]
 				i, val = parseLiteral(c.json, i)
 				if hit {
+					if c.value == nil {
+						c.value = &Result{}
+					}
 					c.value.Raw = val
 					switch vc {
 					case 't':
@@ -1405,6 +1417,9 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 			if num {
 				i, val = parseNumber(c.json, i)
 				if hit {
+					if c.value == nil {
+						c.value = &Result{}
+					}
 					c.value.Raw = val
 					c.value.Type = Number
 					c.value.Num, _ = strconv.ParseFloat(val, 64)
@@ -1633,7 +1648,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					queryIndexes = append(queryIndexes, res.Index+parentIndex)
 				}
 			} else {
-				*c.value = *res
+				c.value = res
 				return true
 			}
 		}
@@ -1683,6 +1698,9 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					if rp.alogok {
 						break
 					}
+					if c.value == nil {
+						c.value = &Result{}
+					}
 					if vesc {
 						c.value.Str = unescape(val[1 : len(val)-1])
 					} else {
@@ -1711,6 +1729,9 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 						if rp.alogok {
 							break
 						}
+						if c.value == nil {
+							c.value = &Result{}
+						}
 						c.value.Raw = val
 						c.value.Type = JSON
 						return i, true
@@ -1734,6 +1755,9 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					} else if hit {
 						if rp.alogok {
 							break
+						}
+						if c.value == nil {
+							c.value = &Result{}
 						}
 						c.value.Raw = val
 						c.value.Type = JSON
@@ -1764,6 +1788,9 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				} else if hit {
 					if rp.alogok {
 						break
+					}
+					if c.value == nil {
+						c.value = &Result{}
 					}
 					c.value.Raw = val
 					switch vc {
@@ -1819,6 +1846,9 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 							}
 						}
 						jsons = append(jsons, ']')
+						if c.value == nil {
+							c.value = &Result{}
+						}
 						c.value.Type = JSON
 						c.value.Raw = string(jsons)
 						c.value.Indexes = indexes
@@ -1827,21 +1857,31 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					if rp.alogok {
 						break
 					}
-
+					if c.value == nil {
+						c.value = &Result{}
+					}
 					c.value.Type = Number
 					c.value.Num = float64(h - 1)
 					c.value.Raw = strconv.Itoa(h - 1)
 					c.calcd = true
 					return i + 1, true
 				}
-				if !c.value.Exists() {
+				if c.value == nil || !c.value.Exists() {
 					if len(multires) > 0 {
-						c.value.Clear()
+						if c.value == nil {
+							c.value = &Result{}
+						} else {
+							c.value.Clear()
+						}
 						c.value.Raw = string(append(multires, ']'))
 						c.value.Type = JSON
 						c.value.Indexes = queryIndexes
 					} else if rp.query.all {
-						c.value.Clear()
+						if c.value == nil {
+							c.value = &Result{}
+						} else {
+							c.value.Clear()
+						}
 						c.value.Raw="[]"
 						c.value.Type=JSON
 					}
@@ -1861,6 +1901,9 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				} else if hit {
 					if rp.alogok {
 						break
+					}
+					if c.value == nil {
+						c.value = &Result{}
 					}
 					c.value.Raw = val
 					c.value.Type = Number
@@ -3449,6 +3492,9 @@ func getBytes(json []byte, path string) *Result {
 // of the resulting value. If the position cannot be found then Index zero is
 // used instead.
 func fillIndex(json string, c *parseContext) {
+	if c.value == nil {
+		c.value = &Result{}
+	}
 	if len(c.value.Raw) > 0 && !c.calcd {
 		jhdr := *(*stringHeader)(unsafe.Pointer(&json))
 		rhdr := *(*stringHeader)(unsafe.Pointer(&(c.value.Raw)))

--- a/gjson.go
+++ b/gjson.go
@@ -1230,34 +1230,34 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 		c.pipe = rp.pipe
 		c.piped = true
 	}
-	for i < len(c.json) {
-		for ; i < len(c.json); i++ {
-			if c.json[i] == '"' {
+	for i < len(*c.json) {
+		for ; i < len(*c.json); i++ {
+			if (*c.json)[i] == '"' {
 				// parse_key_string
 				// this is slightly different from getting s string value
 				// because we don't need the outer quotes.
 				i++
 				s := i
-				for ; i < len(c.json); i++ {
-					if c.json[i] > '\\' {
+				for ; i < len(*c.json); i++ {
+					if (*c.json)[i] > '\\' {
 						continue
 					}
-					if c.json[i] == '"' {
-						i, key, kesc, ok = i+1, c.json[s:i], false, true
+					if (*c.json)[i] == '"' {
+						i, key, kesc, ok = i+1, (*c.json)[s:i], false, true
 						goto parse_key_string_done
 					}
-					if c.json[i] == '\\' {
+					if (*c.json)[i] == '\\' {
 						i++
-						for ; i < len(c.json); i++ {
-							if c.json[i] > '\\' {
+						for ; i < len((*c.json)); i++ {
+							if (*c.json)[i] > '\\' {
 								continue
 							}
-							if c.json[i] == '"' {
+							if (*c.json)[i] == '"' {
 								// look for an escaped slash
-								if c.json[i-1] == '\\' {
+								if (*c.json)[i-1] == '\\' {
 									n := 0
 									for j := i - 2; j > 0; j-- {
-										if c.json[j] != '\\' {
+										if (*c.json)[j] != '\\' {
 											break
 										}
 										n++
@@ -1266,18 +1266,18 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 										continue
 									}
 								}
-								i, key, kesc, ok = i+1, c.json[s:i], true, true
+								i, key, kesc, ok = i+1, (*c.json)[s:i], true, true
 								goto parse_key_string_done
 							}
 						}
 						break
 					}
 				}
-				key, kesc, ok = c.json[s:], false, false
+				key, kesc, ok = (*c.json)[s:], false, false
 			parse_key_string_done:
 				break
 			}
-			if c.json[i] == '}' {
+			if (*c.json)[i] == '}' {
 				return i + 1, false
 			}
 		}
@@ -1298,14 +1298,14 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 			}
 		}
 		hit = pmatch && !rp.more
-		for ; i < len(c.json); i++ {
+		for ; i < len((*c.json)); i++ {
 			var num bool
-			switch c.json[i] {
+			switch (*c.json)[i] {
 			default:
 				continue
 			case '"':
 				i++
-				i, val, vesc, ok = parseString(c.json, i)
+				i, val, vesc, ok = parseString((*c.json), i)
 				if !ok {
 					return i, false
 				}
@@ -1326,7 +1326,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 						return i, true
 					}
 				} else {
-					i, val = parseSquash(c.json, i)
+					i, val = parseSquash((*c.json), i)
 					if hit {
 						c.value.Raw = val
 						c.value.Type = JSON
@@ -1340,7 +1340,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 						return i, true
 					}
 				} else {
-					i, val = parseSquash(c.json, i)
+					i, val = parseSquash((*c.json), i)
 					if hit {
 						c.value.Raw = val
 						c.value.Type = JSON
@@ -1348,14 +1348,14 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 					}
 				}
 			case 'n':
-				if i+1 < len(c.json) && c.json[i+1] != 'u' {
+				if i+1 < len((*c.json)) && (*c.json)[i+1] != 'u' {
 					num = true
 					break
 				}
 				fallthrough
 			case 't', 'f':
-				vc := c.json[i]
-				i, val = parseLiteral(c.json, i)
+				vc := (*c.json)[i]
+				i, val = parseLiteral((*c.json), i)
 				if hit {
 					c.value.Raw = val
 					switch vc {
@@ -1371,7 +1371,7 @@ func parseObject(c *parseContext, i int, path string) (int, bool) {
 				num = true
 			}
 			if num {
-				i, val = parseNumber(c.json, i)
+				i, val = parseNumber((*c.json), i)
 				if hit {
 					c.value.Raw = val
 					c.value.Type = Number
@@ -1565,7 +1565,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 		}
 		tmp := parseContext{value: &Result{}}
 		*tmp.value = *qval
-		fillIndex(c.json, &tmp)
+		fillIndex((*c.json), &tmp)
 		parentIndex := tmp.value.Index
 		res := &Result{}
 		if qval.Type == JSON {
@@ -1607,7 +1607,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 		}
 		return false
 	}
-	for i < len(c.json)+1 {
+	for i < len((*c.json))+1 {
 		if !rp.arrch {
 			pmatch = partidx == h
 			hit = pmatch && !rp.more
@@ -1618,12 +1618,12 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 		}
 		for ; ; i++ {
 			var ch byte
-			if i > len(c.json) {
+			if i > len((*c.json)) {
 				break
-			} else if i == len(c.json) {
+			} else if i == len((*c.json)) {
 				ch = ']'
 			} else {
-				ch = c.json[i]
+				ch = (*c.json)[i]
 			}
 			var num bool
 			switch ch {
@@ -1631,7 +1631,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				continue
 			case '"':
 				i++
-				i, val, vesc, ok = parseString(c.json, i)
+				i, val, vesc, ok = parseString((*c.json), i)
 				if !ok {
 					return i, false
 				}
@@ -1670,7 +1670,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 						return i, true
 					}
 				} else {
-					i, val = parseSquash(c.json, i)
+					i, val = parseSquash((*c.json), i)
 					if rp.query.on {
 						if procQuery(&Result{Raw: val, Type: JSON}) {
 							return i, true
@@ -1694,7 +1694,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 						return i, true
 					}
 				} else {
-					i, val = parseSquash(c.json, i)
+					i, val = parseSquash((*c.json), i)
 					if rp.query.on {
 						if procQuery(&Result{Raw: val, Type: JSON}) {
 							return i, true
@@ -1709,14 +1709,14 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 					}
 				}
 			case 'n':
-				if i+1 < len(c.json) && c.json[i+1] != 'u' {
+				if i+1 < len((*c.json)) && (*c.json)[i+1] != 'u' {
 					num = true
 					break
 				}
 				fallthrough
 			case 't', 'f':
-				vc := c.json[i]
-				i, val = parseLiteral(c.json, i)
+				vc := (*c.json)[i]
+				i, val = parseLiteral((*c.json), i)
 				if rp.query.on {
 					var qval Result
 					qval.Raw = val
@@ -1759,16 +1759,16 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 						jsons = append(jsons, '[')
 						for j, k := 0, 0; j < len(alog); j++ {
 							idx := alog[j]
-							for idx < len(c.json) {
-								switch c.json[idx] {
+							for idx < len((*c.json)) {
+								switch (*c.json)[idx] {
 								case ' ', '\t', '\r', '\n':
 									idx++
 									continue
 								}
 								break
 							}
-							if idx < len(c.json) && c.json[idx] != ']' {
-								_, res, ok := parseAny(c.json, idx, true)
+							if idx < len((*c.json)) && (*c.json)[idx] != ']' {
+								_, res, ok := parseAny((*c.json), idx, true)
 								if ok {
 									res := res.Get(rp.alogkey)
 									if res.Exists() {
@@ -1817,7 +1817,7 @@ func parseArray(c *parseContext, i int, path string) (int, bool) {
 				return i + 1, false
 			}
 			if num {
-				i, val = parseNumber(c.json, i)
+				i, val = parseNumber((*c.json), i)
 				if rp.query.on {
 					var qval Result
 					qval.Raw = val
@@ -2114,7 +2114,7 @@ func AppendJSONString(dst []byte, s string) []byte {
 }
 
 type parseContext struct {
-	json  string
+	json  *string
 	value *Result
 	pipe  string
 	piped bool
@@ -2240,18 +2240,18 @@ func Get(json, path string) *Result {
 	}
 	var i int
 	c := parseContext{value: &Result{}}
-	c.json = json
+	c.json = &json
 	if len(path) >= 2 && path[0] == '.' && path[1] == '.' {
 		c.lines = true
 		parseArray(&c, 0, path[2:])
 	} else {
-		for ; i < len(c.json); i++ {
-			if c.json[i] == '{' {
+		for ; i < len((*c.json)); i++ {
+			if (*c.json)[i] == '{' {
 				i++
 				parseObject(&c, i, path)
 				break
 			}
-			if c.json[i] == '[' {
+			if (*c.json)[i] == '[' {
 				i++
 				parseArray(&c, i, path)
 				break

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -1385,10 +1385,10 @@ func TestArrayValues(t *testing.T) {
 	}
 	expect := strings.Join([]string{
 		`&gjson.Result{Type:3, Raw:"\"PERSON1\"", Str:"PERSON1", Num:0, ` +
-			`Index:11, Indexes:[]int(nil)}`,
+			`Index:11, Indexes:[]int(nil), children:[]*gjson.Result(nil), nopool:false}`,
 		`&gjson.Result{Type:3, Raw:"\"PERSON2\"", Str:"PERSON2", Num:0, ` +
-			`Index:21, Indexes:[]int(nil)}`,
-		`&gjson.Result{Type:2, Raw:"0", Str:"", Num:0, Index:31, Indexes:[]int(nil)}`,
+			`Index:21, Indexes:[]int(nil), children:[]*gjson.Result(nil), nopool:false}`,
+		`&gjson.Result{Type:2, Raw:"0", Str:"", Num:0, Index:31, Indexes:[]int(nil), children:[]*gjson.Result(nil), nopool:false}`,
 	}, "\n")
 	if output != expect {
 		t.Fatalf("expected '%v', got '%v'", expect, output)

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -1902,6 +1902,32 @@ func TestSingleModifier(t *testing.T) {
 	assert(t, Get(data, "\\@key").String() == "value")
 }
 
+func TestGetWithReused(t *testing.T) {
+	AddModifier("case", func(json, arg string) string {
+		if arg == "upper" {
+			return strings.ToUpper(json)
+		}
+		if arg == "lower" {
+			return strings.ToLower(json)
+		}
+		return json
+	})
+	r := &Result{}
+	r.Parse(`{"friends": [
+		{"age": 44, "first": "Dale", "last": "Murphy"},
+		{"age": 68, "first": "Roger", "last": "Craig"},
+		{"age": 47, "first": "Jane", "last": "Murphy"}
+	]}`)
+	res := r.Get(`{friends.#.{age,first:first|@case:upper}|0.first}`)
+	exp := `{"first":"DALE"}`
+	assert(t, res.Raw == exp)
+	r.Clear()
+	r.Parse(readmeJSON)
+	res = r.Get(`{"children":children|@case:upper,"name":name.first,"age":age}`)
+	exp = `{"children":["SARA","ALEX","JACK"],"name":"Tom","age":37}`
+	assert(t, res.Raw == exp)
+}
+
 func TestModifiersInMultipaths(t *testing.T) {
 	AddModifier("case", func(json, arg string) string {
 		if arg == "upper" {

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -69,7 +69,10 @@ func TestEmoji(t *testing.T) {
 		`OK: \u2764\ufe0f "}`
 	value := Get(input, "utf8")
 	var s string
-	json.Unmarshal([]byte(value.Raw), &s)
+	err := json.Unmarshal([]byte(value.Raw), &s)
+	if err != nil {
+		t.Fatalf("got error: %s", err)
+	}
 	if value.String() != s {
 		t.Fatalf("expected '%v', got '%v'", s, value.String())
 	}
@@ -159,7 +162,7 @@ func TestPath(t *testing.T) {
 	}
 
 	obj := Parse(json)
-	obj.ForEach(func(key, val Result) bool {
+	obj.ForEach(func(key, val *Result) bool {
 		kp := key.Path(json)
 		assert(t, kp == "")
 		vp := val.Path(json)
@@ -172,7 +175,7 @@ func TestPath(t *testing.T) {
 		return true
 	})
 	arr := obj.Get("loggy.programmers")
-	arr.ForEach(func(_, val Result) bool {
+	arr.ForEach(func(_, val *Result) bool {
 		vp := val.Path(json)
 		val2 := Get(json, vp)
 		assert(t, val2.Raw == val.Raw)
@@ -199,7 +202,6 @@ func TestPath(t *testing.T) {
 	get("loggy.programmers.2.email")
 	get("lastly.end\\.\\.\\.ing")
 	get("lastly.yay")
-
 }
 
 func TestTimeResult(t *testing.T) {
@@ -216,8 +218,10 @@ func TestParseAny(t *testing.T) {
 
 func TestManyVariousPathCounts(t *testing.T) {
 	json := `{"a":"a","b":"b","c":"c"}`
-	counts := []int{3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127,
-		128, 129, 255, 256, 257, 511, 512, 513}
+	counts := []int{
+		3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127,
+		128, 129, 255, 256, 257, 511, 512, 513,
+	}
 	paths := []string{"a", "b", "c"}
 	expects := []string{"a", "b", "c"}
 	for _, count := range counts {
@@ -238,6 +242,7 @@ func TestManyVariousPathCounts(t *testing.T) {
 		}
 	}
 }
+
 func TestManyRecursion(t *testing.T) {
 	var json string
 	var path string
@@ -252,6 +257,7 @@ func TestManyRecursion(t *testing.T) {
 	path = path[1:]
 	assert(t, GetMany(json, path)[0].String() == "b")
 }
+
 func TestByteSafety(t *testing.T) {
 	jsonb := []byte(`{"name":"Janet","age":38}`)
 	mtok := GetBytes(jsonb, "name")
@@ -270,12 +276,12 @@ func TestByteSafety(t *testing.T) {
 	}
 }
 
-func get(json, path string) Result {
+func get(json, path string) *Result {
 	return GetBytes([]byte(json), path)
 }
 
 func TestBasic(t *testing.T) {
-	var mtok Result
+	var mtok *Result
 	mtok = get(basicJSON, `loggy.programmers.#[tag="good"].firstName`)
 	if mtok.String() != "Brett" {
 		t.Fatalf("expected %v, got %v", "Brett", mtok.String())
@@ -348,6 +354,7 @@ func TestPlus53BitInts(t *testing.T) {
 	// flip the number to the negative sign.
 	assert(t, Get(json, "overflow_int64").Int() == -9223372036854775808)
 }
+
 func TestIssue38(t *testing.T) {
 	// These should not fail, even though the unicode is invalid.
 	Get(`["S3O PEDRO DO BUTI\udf93"]`, "0")
@@ -359,6 +366,7 @@ func TestIssue38(t *testing.T) {
 	Get(`["S3O PEDRO DO BUTI\udf93\u1345"]`, "0")
 	Get(`["S3O PEDRO DO BUTI\udf93\u1345asd"]`, "0")
 }
+
 func TestTypes(t *testing.T) {
 	assert(t, (Result{Type: String}).Type.String() == "String")
 	assert(t, (Result{Type: Number}).Type.String() == "Number")
@@ -368,54 +376,55 @@ func TestTypes(t *testing.T) {
 	assert(t, (Result{Type: JSON}).Type.String() == "JSON")
 	assert(t, (Result{Type: 100}).Type.String() == "")
 	// bool
-	assert(t, (Result{Type: True}).Bool() == true)
-	assert(t, (Result{Type: False}).Bool() == false)
-	assert(t, (Result{Type: Number, Num: 1}).Bool() == true)
-	assert(t, (Result{Type: Number, Num: 0}).Bool() == false)
-	assert(t, (Result{Type: String, Str: "1"}).Bool() == true)
-	assert(t, (Result{Type: String, Str: "T"}).Bool() == true)
-	assert(t, (Result{Type: String, Str: "t"}).Bool() == true)
-	assert(t, (Result{Type: String, Str: "true"}).Bool() == true)
-	assert(t, (Result{Type: String, Str: "True"}).Bool() == true)
-	assert(t, (Result{Type: String, Str: "TRUE"}).Bool() == true)
-	assert(t, (Result{Type: String, Str: "tRuE"}).Bool() == true)
-	assert(t, (Result{Type: String, Str: "0"}).Bool() == false)
-	assert(t, (Result{Type: String, Str: "f"}).Bool() == false)
-	assert(t, (Result{Type: String, Str: "F"}).Bool() == false)
-	assert(t, (Result{Type: String, Str: "false"}).Bool() == false)
-	assert(t, (Result{Type: String, Str: "False"}).Bool() == false)
-	assert(t, (Result{Type: String, Str: "FALSE"}).Bool() == false)
-	assert(t, (Result{Type: String, Str: "fAlSe"}).Bool() == false)
-	assert(t, (Result{Type: String, Str: "random"}).Bool() == false)
+	assert(t, (&Result{Type: True}).Bool() == true)
+	assert(t, (&Result{Type: False}).Bool() == false)
+	assert(t, (&Result{Type: Number, Num: 1}).Bool() == true)
+	assert(t, (&Result{Type: Number, Num: 0}).Bool() == false)
+	assert(t, (&Result{Type: String, Str: "1"}).Bool() == true)
+	assert(t, (&Result{Type: String, Str: "T"}).Bool() == true)
+	assert(t, (&Result{Type: String, Str: "t"}).Bool() == true)
+	assert(t, (&Result{Type: String, Str: "true"}).Bool() == true)
+	assert(t, (&Result{Type: String, Str: "True"}).Bool() == true)
+	assert(t, (&Result{Type: String, Str: "TRUE"}).Bool() == true)
+	assert(t, (&Result{Type: String, Str: "tRuE"}).Bool() == true)
+	assert(t, (&Result{Type: String, Str: "0"}).Bool() == false)
+	assert(t, (&Result{Type: String, Str: "f"}).Bool() == false)
+	assert(t, (&Result{Type: String, Str: "F"}).Bool() == false)
+	assert(t, (&Result{Type: String, Str: "false"}).Bool() == false)
+	assert(t, (&Result{Type: String, Str: "False"}).Bool() == false)
+	assert(t, (&Result{Type: String, Str: "FALSE"}).Bool() == false)
+	assert(t, (&Result{Type: String, Str: "fAlSe"}).Bool() == false)
+	assert(t, (&Result{Type: String, Str: "random"}).Bool() == false)
 
 	// int
-	assert(t, (Result{Type: String, Str: "1"}).Int() == 1)
-	assert(t, (Result{Type: True}).Int() == 1)
-	assert(t, (Result{Type: False}).Int() == 0)
-	assert(t, (Result{Type: Number, Num: 1}).Int() == 1)
+	assert(t, (&Result{Type: String, Str: "1"}).Int() == 1)
+	assert(t, (&Result{Type: True}).Int() == 1)
+	assert(t, (&Result{Type: False}).Int() == 0)
+	assert(t, (&Result{Type: Number, Num: 1}).Int() == 1)
 	// uint
-	assert(t, (Result{Type: String, Str: "1"}).Uint() == 1)
-	assert(t, (Result{Type: True}).Uint() == 1)
-	assert(t, (Result{Type: False}).Uint() == 0)
-	assert(t, (Result{Type: Number, Num: 1}).Uint() == 1)
+	assert(t, (&Result{Type: String, Str: "1"}).Uint() == 1)
+	assert(t, (&Result{Type: True}).Uint() == 1)
+	assert(t, (&Result{Type: False}).Uint() == 0)
+	assert(t, (&Result{Type: Number, Num: 1}).Uint() == 1)
 	// float
-	assert(t, (Result{Type: String, Str: "1"}).Float() == 1)
-	assert(t, (Result{Type: True}).Float() == 1)
-	assert(t, (Result{Type: False}).Float() == 0)
-	assert(t, (Result{Type: Number, Num: 1}).Float() == 1)
+	assert(t, (&Result{Type: String, Str: "1"}).Float() == 1)
+	assert(t, (&Result{Type: True}).Float() == 1)
+	assert(t, (&Result{Type: False}).Float() == 0)
+	assert(t, (&Result{Type: Number, Num: 1}).Float() == 1)
 }
+
 func TestForEach(t *testing.T) {
-	Result{}.ForEach(nil)
-	Result{Type: String, Str: "Hello"}.ForEach(func(_, value Result) bool {
+	(&Result{}).ForEach(nil)
+	(&Result{Type: String, Str: "Hello"}).ForEach(func(_, value *Result) bool {
 		assert(t, value.String() == "Hello")
 		return false
 	})
-	Result{Type: JSON, Raw: "*invalid*"}.ForEach(nil)
+	(&Result{Type: JSON, Raw: "*invalid*"}).ForEach(nil)
 
 	json := ` {"name": {"first": "Janet","last": "Prichard"},
 	"asd\nf":"\ud83d\udd13","age": 47}`
 	var count int
-	ParseBytes([]byte(json)).ForEach(func(key, value Result) bool {
+	ParseBytes([]byte(json)).ForEach(func(key, value *Result) bool {
 		count++
 		return true
 	})
@@ -423,18 +432,20 @@ func TestForEach(t *testing.T) {
 	ParseBytes([]byte(`{"bad`)).ForEach(nil)
 	ParseBytes([]byte(`{"ok":"bad`)).ForEach(nil)
 }
+
 func TestMap(t *testing.T) {
 	assert(t, len(ParseBytes([]byte(`"asdf"`)).Map()) == 0)
 	assert(t, ParseBytes([]byte(`{"asdf":"ghjk"`)).Map()["asdf"].String() ==
 		"ghjk")
-	assert(t, len(Result{Type: JSON, Raw: "**invalid**"}.Map()) == 0)
-	assert(t, Result{Type: JSON, Raw: "**invalid**"}.Value() == nil)
-	assert(t, Result{Type: JSON, Raw: "{"}.Map() != nil)
+	assert(t, len((&Result{Type: JSON, Raw: "**invalid**"}).Map()) == 0)
+	assert(t, (&Result{Type: JSON, Raw: "**invalid**"}).Value() == nil)
+	assert(t, (&Result{Type: JSON, Raw: "{"}).Map() != nil)
 }
+
 func TestBasic1(t *testing.T) {
 	mtok := get(basicJSON, `loggy.programmers`)
 	var count int
-	mtok.ForEach(func(key, value Result) bool {
+	mtok.ForEach(func(key, value *Result) bool {
 		assert(t, key.Exists())
 		assert(t, key.String() == fmt.Sprint(count))
 		assert(t, key.Int() == int64(count))
@@ -444,7 +455,7 @@ func TestBasic1(t *testing.T) {
 		}
 		if count == 1 {
 			i := 0
-			value.ForEach(func(key, value Result) bool {
+			value.ForEach(func(key, value *Result) bool {
 				switch i {
 				case 0:
 					if key.String() != "firstName" ||
@@ -474,6 +485,7 @@ func TestBasic1(t *testing.T) {
 		t.Fatalf("expected %v, got %v", 3, count)
 	}
 }
+
 func TestBasic2(t *testing.T) {
 	mtok := get(basicJSON, `loggy.programmers.#[age=101].firstName`)
 	if mtok.String() != "1002.3" {
@@ -509,14 +521,15 @@ func TestBasic2(t *testing.T) {
 			mtok.Map()["programmers"].Array()[1].Map()["firstName"].Str)
 	}
 }
+
 func TestBasic3(t *testing.T) {
-	var mtok Result
+	var mtok *Result
 	if Parse(basicJSON).Get("loggy.programmers").Get("1").
 		Get("firstName").Str != "Jason" {
 		t.Fatalf("expected %v, got %v", "Jason", Parse(basicJSON).
 			Get("loggy.programmers").Get("1").Get("firstName").Str)
 	}
-	var token Result
+	var token *Result
 	if token = Parse("-102"); token.Num != -102 {
 		t.Fatalf("expected %v, got %v", -102, token.Num)
 	}
@@ -549,6 +562,7 @@ func TestBasic3(t *testing.T) {
 		t.Fatalf("expected 0, got %v", len(mtok.Array()))
 	}
 }
+
 func TestBasic4(t *testing.T) {
 	if get(basicJSON, "items.3.tags.#").Num != 3 {
 		t.Fatalf("expected 3, got %v", get(basicJSON, "items.3.tags.#").Num)
@@ -593,6 +607,7 @@ func TestBasic4(t *testing.T) {
 		t.Fatal("should be nil")
 	}
 }
+
 func TestBasic5(t *testing.T) {
 	token := get(basicJSON, "age")
 	if token.String() != "100" {
@@ -630,8 +645,9 @@ func TestBasic5(t *testing.T) {
 		t.Fatalf("expecting %v, got %v", "Jason", fn)
 	}
 }
+
 func TestUnicode(t *testing.T) {
-	var json = `{"key":0,"的情况下解":{"key":1,"的情况":2}}`
+	json := `{"key":0,"的情况下解":{"key":1,"的情况":2}}`
 	if Get(json, "的情况下解.key").Num != 1 {
 		t.Fatal("fail")
 	}
@@ -659,32 +675,46 @@ func TestUnescape(t *testing.T) {
 	unescape(string([]byte{'\\', '\\', 0}))
 	unescape(string([]byte{'\\', '/', '\\', 'b', '\\', 'f'}))
 }
-func assert(t testing.TB, cond bool) {
+
+func assert(_ testing.TB, cond bool) {
 	if !cond {
 		panic("assert failed")
 	}
 }
+
 func TestLess(t *testing.T) {
-	assert(t, !Result{Type: Null}.Less(Result{Type: Null}, true))
-	assert(t, Result{Type: Null}.Less(Result{Type: False}, true))
-	assert(t, Result{Type: Null}.Less(Result{Type: True}, true))
-	assert(t, Result{Type: Null}.Less(Result{Type: JSON}, true))
-	assert(t, Result{Type: Null}.Less(Result{Type: Number}, true))
-	assert(t, Result{Type: Null}.Less(Result{Type: String}, true))
-	assert(t, !Result{Type: False}.Less(Result{Type: Null}, true))
-	assert(t, Result{Type: False}.Less(Result{Type: True}, true))
-	assert(t, Result{Type: String, Str: "abc"}.Less(Result{Type: String,
-		Str: "bcd"}, true))
-	assert(t, Result{Type: String, Str: "ABC"}.Less(Result{Type: String,
-		Str: "abc"}, true))
-	assert(t, !Result{Type: String, Str: "ABC"}.Less(Result{Type: String,
-		Str: "abc"}, false))
-	assert(t, Result{Type: Number, Num: 123}.Less(Result{Type: Number,
-		Num: 456}, true))
-	assert(t, !Result{Type: Number, Num: 456}.Less(Result{Type: Number,
-		Num: 123}, true))
-	assert(t, !Result{Type: Number, Num: 456}.Less(Result{Type: Number,
-		Num: 456}, true))
+	assert(t, !(&Result{Type: Null}).Less(&Result{Type: Null}, true))
+	assert(t, (&Result{Type: Null}).Less(&Result{Type: False}, true))
+	assert(t, (&Result{Type: Null}).Less(&Result{Type: True}, true))
+	assert(t, (&Result{Type: Null}).Less(&Result{Type: JSON}, true))
+	assert(t, (&Result{Type: Null}).Less(&Result{Type: Number}, true))
+	assert(t, (&Result{Type: Null}).Less(&Result{Type: String}, true))
+	assert(t, !(&Result{Type: False}).Less(&Result{Type: Null}, true))
+	assert(t, (&Result{Type: False}).Less(&Result{Type: True}, true))
+	assert(t, (&Result{Type: String, Str: "abc"}).Less(&Result{
+		Type: String,
+		Str:  "bcd",
+	}, true))
+	assert(t, (&Result{Type: String, Str: "ABC"}).Less(&Result{
+		Type: String,
+		Str:  "abc",
+	}, true))
+	assert(t, !(&Result{Type: String, Str: "ABC"}).Less(&Result{
+		Type: String,
+		Str:  "abc",
+	}, false))
+	assert(t, (&Result{Type: Number, Num: 123}).Less(&Result{
+		Type: Number,
+		Num:  456,
+	}, true))
+	assert(t, !(&Result{Type: Number, Num: 456}).Less(&Result{
+		Type: Number,
+		Num:  123,
+	}, true))
+	assert(t, !(&Result{Type: Number, Num: 456}).Less(&Result{
+		Type: Number,
+		Num:  456,
+	}, true))
 	assert(t, stringLessInsensitive("abcde", "BBCDE"))
 	assert(t, stringLessInsensitive("abcde", "bBCDE"))
 	assert(t, stringLessInsensitive("Abcde", "BBCDE"))
@@ -776,7 +806,7 @@ var exampleJSON = `{
 }`
 
 func TestUnmarshalMap(t *testing.T) {
-	var m1 = Parse(exampleJSON).Value().(map[string]interface{})
+	m1 := Parse(exampleJSON).Value().(map[string]interface{})
 	var m2 map[string]interface{}
 	if err := json.Unmarshal([]byte(exampleJSON), &m2); err != nil {
 		t.Fatal(err)
@@ -795,9 +825,9 @@ func TestUnmarshalMap(t *testing.T) {
 }
 
 func TestSingleArrayValue(t *testing.T) {
-	var json = `{"key": "value","key2":[1,2,3,4,"A"]}`
-	var result = Get(json, "key")
-	var array = result.Array()
+	json := `{"key": "value","key2":[1,2,3,4,"A"]}`
+	result := Get(json, "key")
+	array := result.Array()
 	if len(array) != 1 {
 		t.Fatal("array is empty")
 	}
@@ -814,7 +844,6 @@ func TestSingleArrayValue(t *testing.T) {
 	if len(array) != 0 {
 		t.Fatalf("got '%v', expected '%v'", len(array), 0)
 	}
-
 }
 
 var manyJSON = `  {
@@ -842,7 +871,7 @@ func TestManyBasic(t *testing.T) {
 	defer func() {
 		testWatchForFallback = false
 	}()
-	testMany := func(shouldFallback bool, expect string, paths ...string) {
+	testMany := func(_ bool, expect string, paths ...string) {
 		results := GetManyBytes(
 			[]byte(manyJSON),
 			paths...,
@@ -867,13 +896,16 @@ func TestManyBasic(t *testing.T) {
 	testMany(true, `[Cat Nancy]`, "name\\.first", "name.first")
 	testMany(true, `[world]`, strings.Repeat("a.", 70)+"hello")
 }
+
 func testMany(t *testing.T, json string, paths, expected []string) {
 	testManyAny(t, json, paths, expected, true)
 	testManyAny(t, json, paths, expected, false)
 }
+
 func testManyAny(t *testing.T, json string, paths, expected []string,
-	bytes bool) {
-	var result []Result
+	bytes bool,
+) {
+	var result []*Result
 	for i := 0; i < 2; i++ {
 		var which string
 		if i == 0 {
@@ -902,6 +934,7 @@ func testManyAny(t *testing.T, json string, paths, expected []string,
 		}
 	}
 }
+
 func TestIssue20(t *testing.T) {
 	json := `{ "name": "FirstName", "name1": "FirstName1", ` +
 		`"address": "address1", "addressDetails": "address2", }`
@@ -918,10 +951,14 @@ func TestIssue21(t *testing.T) {
 	           "Level1Field4":4,
 			   "Level1Field2":{ "Level2Field1":[ "value1", "value2" ],
 			   "Level2Field2":{ "Level3Field1":[ { "key1":"value1" } ] } } }`
-	paths := []string{"Level1Field1", "Level1Field2.Level2Field1",
-		"Level1Field2.Level2Field2.Level3Field1", "Level1Field4"}
-	expected := []string{"3", `[ "value1", "value2" ]`,
-		`[ { "key1":"value1" } ]`, "4"}
+	paths := []string{
+		"Level1Field1", "Level1Field2.Level2Field1",
+		"Level1Field2.Level2Field2.Level3Field1", "Level1Field4",
+	}
+	expected := []string{
+		"3", `[ "value1", "value2" ]`,
+		`[ { "key1":"value1" } ]`, "4",
+	}
 	t.Run("SingleMany", func(t *testing.T) {
 		testMany(t, json, paths,
 			expected)
@@ -1097,8 +1134,10 @@ func TestValidBasic(t *testing.T) {
 	testvalid(t, "[-.123]", false)
 }
 
-var jsonchars = []string{"{", "[", ",", ":", "}", "]", "1", "0", "true",
-	"false", "null", `""`, `"\""`, `"a"`}
+var jsonchars = []string{
+	"{", "[", ",", ":", "}", "]", "1", "0", "true",
+	"false", "null", `""`, `"\""`, `"a"`,
+}
 
 func makeRandomJSONChars(b []byte) {
 	var bb []byte
@@ -1188,7 +1227,7 @@ func TestNullArray(t *testing.T) {
 }
 
 func TestIssue54(t *testing.T) {
-	var r []Result
+	var r []*Result
 	json := `{"MarketName":null,"Nounce":6115}`
 	r = GetMany(json, "Nounce", "Buys", "Sells", "Fills")
 	if strings.Replace(fmt.Sprintf("%v", r), " ", "", -1) != "[6115]" {
@@ -1217,6 +1256,7 @@ func TestIssue55(t *testing.T) {
 		}
 	}
 }
+
 func TestIssue58(t *testing.T) {
 	json := `{"data":[{"uid": 1},{"uid": 2}]}`
 	res := Get(json, `data.#[uid!=1]`).Raw
@@ -1269,7 +1309,7 @@ null
 
 	var i int
 	lines := strings.Split(strings.TrimSpace(json), "\n")
-	ForEachLine(json, func(line Result) bool {
+	ForEachLine(json, func(line *Result) bool {
 		if line.Raw != lines[i] {
 			t.Fatalf("expected '%v', got '%v'", lines[i], line.Raw)
 		}
@@ -1279,11 +1319,10 @@ null
 	if i != 4 {
 		t.Fatalf("expected '%v', got '%v'", 4, i)
 	}
-
 }
 
 func TestNumUint64String(t *testing.T) {
-	var i int64 = 9007199254740993 //2^53 + 1
+	var i int64 = 9007199254740993 // 2^53 + 1
 	j := fmt.Sprintf(`{"data":  [  %d, "hello" ] }`, i)
 	res := Get(j, "data.0")
 	if res.String() != "9007199254740993" {
@@ -1312,7 +1351,7 @@ func TestNumBigString(t *testing.T) {
 
 func TestNumFloatString(t *testing.T) {
 	var i int64 = -9007199254740993
-	j := fmt.Sprintf(`{"data":[ "hello", %d ]}`, i) //No quotes around value!!
+	j := fmt.Sprintf(`{"data":[ "hello", %d ]}`, i) // No quotes around value!!
 	res := Get(j, "data.1")
 	if res.String() != "-9007199254740993" {
 		t.Fatalf("expected '%v', got '%v'", "-9007199254740993", res.String())
@@ -1321,7 +1360,7 @@ func TestNumFloatString(t *testing.T) {
 
 func TestDuplicateKeys(t *testing.T) {
 	// this is valid json according to the JSON spec
-	var json = `{"name": "Alex","name": "Peter"}`
+	json := `{"name": "Alex","name": "Peter"}`
 	if Parse(json).Get("name").String() !=
 		Parse(json).Map()["name"].String() {
 		t.Fatalf("expected '%v', got '%v'",
@@ -1335,7 +1374,7 @@ func TestDuplicateKeys(t *testing.T) {
 }
 
 func TestArrayValues(t *testing.T) {
-	var json = `{"array": ["PERSON1","PERSON2",0],}`
+	json := `{"array": ["PERSON1","PERSON2",0],}`
 	values := Get(json, "array").Array()
 	var output string
 	for i, val := range values {
@@ -1345,16 +1384,15 @@ func TestArrayValues(t *testing.T) {
 		output += fmt.Sprintf("%#v", val)
 	}
 	expect := strings.Join([]string{
-		`gjson.Result{Type:3, Raw:"\"PERSON1\"", Str:"PERSON1", Num:0, ` +
+		`&gjson.Result{Type:3, Raw:"\"PERSON1\"", Str:"PERSON1", Num:0, ` +
 			`Index:11, Indexes:[]int(nil)}`,
-		`gjson.Result{Type:3, Raw:"\"PERSON2\"", Str:"PERSON2", Num:0, ` +
+		`&gjson.Result{Type:3, Raw:"\"PERSON2\"", Str:"PERSON2", Num:0, ` +
 			`Index:21, Indexes:[]int(nil)}`,
-		`gjson.Result{Type:2, Raw:"0", Str:"", Num:0, Index:31, Indexes:[]int(nil)}`,
+		`&gjson.Result{Type:2, Raw:"0", Str:"", Num:0, Index:31, Indexes:[]int(nil)}`,
 	}, "\n")
 	if output != expect {
 		t.Fatalf("expected '%v', got '%v'", expect, output)
 	}
-
 }
 
 func BenchmarkValid(b *testing.B) {
@@ -1459,7 +1497,6 @@ func TestSplitPipe(t *testing.T) {
 	split(t, `hello.#[a|1="asdf\"|1324"]#|that.more|yikes`,
 		`hello.#[a|1="asdf\"|1324"]#`, "that.more|yikes", true)
 	split(t, `a.#[]#\|b`, "", "", false)
-
 }
 
 func TestArrayEx(t *testing.T) {
@@ -1705,7 +1742,6 @@ func TestQueries(t *testing.T) {
 	assert(t, Get(json, `i*.f*.#[cust1>=true].first`).Exists())
 	assert(t, !Get(json, `i*.f*.#[cust2<false].first`).Exists())
 	assert(t, Get(json, `i*.f*.#[cust2<=false].first`).Exists())
-
 }
 
 func TestQueryArrayValues(t *testing.T) {
@@ -1797,8 +1833,7 @@ func TestParseQuery(t *testing.T) {
 	var path, op, value, remain string
 	var ok bool
 
-	path, op, value, remain, _, _, ok =
-		parseQuery(`#(service_roles.#(=="one").()==asdf).cap`)
+	path, op, value, remain, _, _, ok = parseQuery(`#(service_roles.#(=="one").()==asdf).cap`)
 	assert(t, ok &&
 		path == `service_roles.#(=="one").()` &&
 		op == "=" &&
@@ -1826,8 +1861,7 @@ func TestParseQuery(t *testing.T) {
 		value == `` &&
 		remain == ``)
 
-	path, op, value, remain, _, _, ok =
-		parseQuery(`#(a\("\"(".#(=="o\"(ne")%"ab\")").remain`)
+	path, op, value, remain, _, _, ok = parseQuery(`#(a\("\"(".#(=="o\"(ne")%"ab\")").remain`)
 	assert(t, ok &&
 		path == `a\("\"(".#(=="o\"(ne")` &&
 		op == "%" &&
@@ -1836,7 +1870,7 @@ func TestParseQuery(t *testing.T) {
 }
 
 func TestParentSubQuery(t *testing.T) {
-	var json = `{
+	json := `{
 		"topology": {
 		  "instances": [
 			{
@@ -1863,7 +1897,7 @@ func TestParentSubQuery(t *testing.T) {
 }
 
 func TestSingleModifier(t *testing.T) {
-	var data = `{"@key": "value"}`
+	data := `{"@key": "value"}`
 	assert(t, Get(data, "@key").String() == "value")
 	assert(t, Get(data, "\\@key").String() == "value")
 }
@@ -1945,7 +1979,7 @@ func TestValid(t *testing.T) {
 
 // https://github.com/tidwall/gjson/issues/152
 func TestJoin152(t *testing.T) {
-	var json = `{
+	json := `{
 		"distance": 1374.0,
 		"validFrom": "2005-11-14",
 		"historical": {
@@ -2086,7 +2120,6 @@ func TestVariousFuzz(t *testing.T) {
 	testJSON1 := `["*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,,,,,,"]`
 	testJSON2 := `#[%"*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,,,,,,""*,*"]`
 	Get(testJSON1, testJSON2)
-
 }
 
 func TestSubpathsWithMultipaths(t *testing.T) {
@@ -2227,11 +2260,10 @@ func TestModifierDoubleQuotes(t *testing.T) {
 		`{"name":"Product P4","value":"{\"productId\":\"1cc3\",\"vendorId\":\"20de\"}"},`+
 		`{"name":"Product P4","value":"{\"productId\":\"1dd3\",\"vendorId\":\"30de\"}"}`+
 		`]`)
-
 }
 
 func TestIndexes(t *testing.T) {
-	var exampleJSON = `{
+	exampleJSON := `{
 		"vals": [
 			[1,66,{test: 3}],
 			[4,5,[6]]
@@ -2276,7 +2308,7 @@ func TestIndexes(t *testing.T) {
 }
 
 func TestIndexesMatchesRaw(t *testing.T) {
-	var exampleJSON = `{
+	exampleJSON := `{
 		"objectArray":[
 			{"first": "Jason", "age": 41},
 			{"first": "Dale", "age": 44},
@@ -2312,7 +2344,7 @@ func TestIssue240(t *testing.T) {
 }
 
 func TestKeysValuesModifier(t *testing.T) {
-	var json = `{
+	json := `{
 		"1300014": {
 		  "code": "1300014",
 		  "price": 59.18,
@@ -2341,11 +2373,15 @@ func TestKeysValuesModifier(t *testing.T) {
 
 func TestNaNInf(t *testing.T) {
 	json := `[+Inf,-Inf,Inf,iNF,-iNF,+iNF,NaN,nan,nAn,-0,+0]`
-	raws := []string{"+Inf", "-Inf", "Inf", "iNF", "-iNF", "+iNF", "NaN", "nan",
-		"nAn", "-0", "+0"}
-	nums := []float64{math.Inf(+1), math.Inf(-1), math.Inf(0), math.Inf(0),
+	raws := []string{
+		"+Inf", "-Inf", "Inf", "iNF", "-iNF", "+iNF", "NaN", "nan",
+		"nAn", "-0", "+0",
+	}
+	nums := []float64{
+		math.Inf(+1), math.Inf(-1), math.Inf(0), math.Inf(0),
 		math.Inf(-1), math.Inf(+1), math.NaN(), math.NaN(), math.NaN(),
-		math.Copysign(0, -1), 0}
+		math.Copysign(0, -1), 0,
+	}
 
 	assert(t, int(Get(json, `#`).Int()) == len(raws))
 	for i := 0; i < len(raws); i++ {
@@ -2356,7 +2392,7 @@ func TestNaNInf(t *testing.T) {
 	}
 
 	var i int
-	Parse(json).ForEach(func(_, r Result) bool {
+	Parse(json).ForEach(func(_, r *Result) bool {
 		assert(t, r.Raw == raws[i])
 		assert(t, r.Num == nums[i] || (math.IsNaN(r.Num) && math.IsNaN(nums[i])))
 		assert(t, r.Type == Number)
@@ -2498,7 +2534,7 @@ func TestArrayKeys(t *testing.T) {
 	}
 	json += "]"
 	var i int
-	Parse(json).ForEach(func(key, value Result) bool {
+	Parse(json).ForEach(func(key, value *Result) bool {
 		assert(t, key.String() == fmt.Sprint(i))
 		assert(t, key.Int() == int64(i))
 		i++
@@ -2579,7 +2615,10 @@ func TestJSONString(t *testing.T) {
 		`OK: \u2764\ufe0f "}`
 	value := Get(input, "utf8")
 	var s string
-	json.Unmarshal([]byte(value.Raw), &s)
+	err := json.Unmarshal([]byte(value.Raw), &s)
+	if err != nil {
+		t.Fatalf("got error: %s", err)
+	}
 	if value.String() != s {
 		t.Fatalf("expected '%v', got '%v'", s, value.String())
 	}
@@ -2647,7 +2686,6 @@ func TestIssue301(t *testing.T) {
 	assert(t, Get(json, `fav\.movie.[0]`).String() == `["Deer Hunter"]`)
 	assert(t, Get(json, `fav\.movie.1`).String() == "")
 	assert(t, Get(json, `fav\.movie.[1]`).String() == "[]")
-
 }
 
 func TestModDig(t *testing.T) {

--- a/gjson_test.go
+++ b/gjson_test.go
@@ -162,7 +162,7 @@ func TestPath(t *testing.T) {
 	}
 
 	obj := Parse(json)
-	obj.ForEach(func(key, val *Result) bool {
+	obj.ForEach(func(key Result, val *Result) bool {
 		kp := key.Path(json)
 		assert(t, kp == "")
 		vp := val.Path(json)
@@ -175,7 +175,7 @@ func TestPath(t *testing.T) {
 		return true
 	})
 	arr := obj.Get("loggy.programmers")
-	arr.ForEach(func(_, val *Result) bool {
+	arr.ForEach(func(_ Result, val *Result) bool {
 		vp := val.Path(json)
 		val2 := Get(json, vp)
 		assert(t, val2.Raw == val.Raw)
@@ -415,7 +415,7 @@ func TestTypes(t *testing.T) {
 
 func TestForEach(t *testing.T) {
 	(&Result{}).ForEach(nil)
-	(&Result{Type: String, Str: "Hello"}).ForEach(func(_, value *Result) bool {
+	(&Result{Type: String, Str: "Hello"}).ForEach(func(_ Result, value *Result) bool {
 		assert(t, value.String() == "Hello")
 		return false
 	})
@@ -424,7 +424,7 @@ func TestForEach(t *testing.T) {
 	json := ` {"name": {"first": "Janet","last": "Prichard"},
 	"asd\nf":"\ud83d\udd13","age": 47}`
 	var count int
-	ParseBytes([]byte(json)).ForEach(func(key, value *Result) bool {
+	ParseBytes([]byte(json)).ForEach(func(key Result, value *Result) bool {
 		count++
 		return true
 	})
@@ -445,7 +445,7 @@ func TestMap(t *testing.T) {
 func TestBasic1(t *testing.T) {
 	mtok := get(basicJSON, `loggy.programmers`)
 	var count int
-	mtok.ForEach(func(key, value *Result) bool {
+	mtok.ForEach(func(key Result, value *Result) bool {
 		assert(t, key.Exists())
 		assert(t, key.String() == fmt.Sprint(count))
 		assert(t, key.Int() == int64(count))
@@ -455,7 +455,7 @@ func TestBasic1(t *testing.T) {
 		}
 		if count == 1 {
 			i := 0
-			value.ForEach(func(key, value *Result) bool {
+			value.ForEach(func(key Result, value *Result) bool {
 				switch i {
 				case 0:
 					if key.String() != "firstName" ||
@@ -2392,7 +2392,7 @@ func TestNaNInf(t *testing.T) {
 	}
 
 	var i int
-	Parse(json).ForEach(func(_, r *Result) bool {
+	Parse(json).ForEach(func(_ Result, r *Result) bool {
 		assert(t, r.Raw == raws[i])
 		assert(t, r.Num == nums[i] || (math.IsNaN(r.Num) && math.IsNaN(nums[i])))
 		assert(t, r.Type == Number)
@@ -2534,7 +2534,7 @@ func TestArrayKeys(t *testing.T) {
 	}
 	json += "]"
 	var i int
-	Parse(json).ForEach(func(key, value *Result) bool {
+	Parse(json).ForEach(func(key Result, value *Result) bool {
 		assert(t, key.String() == fmt.Sprint(i))
 		assert(t, key.Int() == int64(i))
 		i++


### PR DESCRIPTION

This would be an API change if pushed upstream but this change reduces the memory load of so many methods copying Results instead of being mindful of references to Results (which complicates things).